### PR TITLE
Lk/remove casting in tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/Buckle/Belte/bin/Debug/net6.0/Belte.dll",
+            "program": "${workspaceFolder}/src/Buckle/Belte/bin/Debug/net7.0/Belte.dll",
             // "args": [
             //     "-d",
             //     "samples/Hello",

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DIAGDIR:=src/Buckle/Diagnostics
 REPLDIR:=src/Buckle/Repl
 SANDDIR:=src/Sander
 
-NETVER:=net6.0
+NETVER:=net7.0
 SYSTEM:=win-x64
 SLN:=src/Buckle/Buckle.sln
 SSLN:=src/Sander/Sander.sln

--- a/README-dev.md
+++ b/README-dev.md
@@ -13,7 +13,7 @@ OnBoarding:
 
 ## Tools
 
-This project uses the .NET SDK (6.0) for building, wrapped with GNU Make.
+This project uses the .NET SDK (7.0) for building, wrapped with GNU Make.
 
 ## Building Buckle
 

--- a/src/Buckle/Belte/Belte.csproj
+++ b/src/Buckle/Belte/Belte.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/Buckle/Buckle.Tests/Buckle.Tests.csproj
+++ b/src/Buckle/Buckle.Tests/Buckle.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -119,14 +119,14 @@ public class EvaluatorTests {
     [InlineData("var a = 12; a >>>= 5; return a;", 0)]
 
     [InlineData("3.2 + 3.4;", 6.6)]
-    [InlineData("3.2 - 3.4;", -0.2)]
+    [InlineData("3.2 - 3.4;", -0.19999999999999973)]
     [InlineData("10 * 1.5;", 15)]
     [InlineData("10 * (int)1.5;", 10)]
     [InlineData("9 / 2;", 4)]
     [InlineData("9.0 / 2;", 4.5)]
     [InlineData("9 / 2.0;", 4.5)]
     [InlineData("4.1 ** 2;", 16.81)]
-    [InlineData("4.1 ** 2.1;", 19.357355)]
+    [InlineData("4.1 ** 2.1;", 19.35735875876448)]
 
     [InlineData("int a = 10; return a;", 10)]
     [InlineData("int a = 10; return a * a;", 100)]
@@ -179,7 +179,7 @@ public class EvaluatorTests {
 
     [InlineData("type a = typeof(int[]);", null)]
 
-    [InlineData("(decimal)3;", (float)3)]
+    [InlineData("(decimal)3;", 3)]
     [InlineData("(int)3.4;", 3)]
     [InlineData("(int)3.6;", 3)]
     [InlineData("([NotNull]int)3;", 3)]
@@ -765,9 +765,8 @@ public class EvaluatorTests {
         var variables = new Dictionary<VariableSymbol, object>();
         var result = compilation.Evaluate(variables);
 
-        // TODO Will not work if explicitly want a double
-        if (result.value is decimal && (Convert.ToDecimal(expectedValue)).CompareTo(result.value) == 0)
-            expectedValue = Convert.ToDecimal(expectedValue);
+        if (result.value is double && (Convert.ToDouble(expectedValue)).CompareTo(result.value) == 0)
+            expectedValue = Convert.ToDouble(expectedValue);
 
         Assert.Empty(result.diagnostics.FilterOut(DiagnosticType.Warning).ToArray());
         Assert.Equal(expectedValue, result.value);

--- a/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -766,6 +766,9 @@ public class EvaluatorTests {
         var variables = new Dictionary<VariableSymbol, object>();
         var result = compilation.Evaluate(variables);
 
+        if (result.value is float && expectedValue is double d && (float)expectedValue == d )
+            expectedValue = (float)expectedValue;
+
         Assert.Empty(result.diagnostics.FilterOut(DiagnosticType.Warning).ToArray());
         Assert.Equal(expectedValue, result.value);
     }

--- a/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -118,16 +118,15 @@ public class EvaluatorTests {
     [InlineData("var a = -8; a >>>= 1; return a;", 2147483644)]
     [InlineData("var a = 12; a >>>= 5; return a;", 0)]
 
-    // TODO @Logan remove need for casts
-    [InlineData("3.2 + 3.4;", (float)6.6000004)]
-    [InlineData("3.2 - 3.4;", -(float)0.20000005)]
-    [InlineData("10 * 1.5;", (float)15)]
+    [InlineData("3.2 + 3.4;", 6.6)]
+    [InlineData("3.2 - 3.4;", -0.2)]
+    [InlineData("10 * 1.5;", 15)]
     [InlineData("10 * (int)1.5;", 10)]
     [InlineData("9 / 2;", 4)]
-    [InlineData("9.0 / 2;", (float)4.5)]
-    [InlineData("9 / 2.0;", (float)4.5)]
-    [InlineData("4.1 ** 2;", (float)16.81)]
-    [InlineData("4.1 ** 2.1;", (float)19.357355)]
+    [InlineData("9.0 / 2;", 4.5)]
+    [InlineData("9 / 2.0;", 4.5)]
+    [InlineData("4.1 ** 2;", 16.81)]
+    [InlineData("4.1 ** 2.1;", 19.357355)]
 
     [InlineData("int a = 10; return a;", 10)]
     [InlineData("int a = 10; return a * a;", 100)]
@@ -150,8 +149,8 @@ public class EvaluatorTests {
     [InlineData("[NotNull]int a = 0; if (a == 0) { a = 10; } else { a = 5; } return a;", 10)]
     [InlineData("[NotNull]int a = 0; if (a == 4) { a = 10; } else { a = 5; } return a;", 5)]
 
-    [InlineData("decimal[] a = {3.1, 2.56, 5.23123}; return a[2];", (float)5.23123)]
-    [InlineData("var a = {3.1, 2.56, 5.23123}; return a[0];", (float)3.1)]
+    [InlineData("decimal[] a = {3.1, 2.56, 5.23123}; return a[2];", 5.23123)]
+    [InlineData("var a = {3.1, 2.56, 5.23123}; return a[0];", 3.1)]
 
     [InlineData("(null + 3) is null;", true)]
     [InlineData("(null > 3) is null;", true)]
@@ -766,8 +765,9 @@ public class EvaluatorTests {
         var variables = new Dictionary<VariableSymbol, object>();
         var result = compilation.Evaluate(variables);
 
-        if (result.value is float && expectedValue is double d && (float)expectedValue == d )
-            expectedValue = (float)expectedValue;
+        // TODO Will not work if explicitly want a double
+        if (result.value is decimal && (Convert.ToDecimal(expectedValue)).CompareTo(result.value) == 0)
+            expectedValue = Convert.ToDecimal(expectedValue);
 
         Assert.Empty(result.diagnostics.FilterOut(DiagnosticType.Warning).ToArray());
         Assert.Equal(expectedValue, result.value);

--- a/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -156,7 +156,7 @@ public class EvaluatorTests {
     [InlineData("(null > 3) is null;", true)]
     [InlineData("null || true;", true)]
 
-    // TODO add these tests and implement required features (refs and is/isnt type)
+    // TODO Add these tests and implement required features (refs and is/isnt type)
     // It is commented out right now because theses features are bigger than was expected,
     // So these features are not going to be added in this PR
     // [InlineData("int x = 4; ref int y = ref x; x++; return y;", 5)]
@@ -329,8 +329,6 @@ public class EvaluatorTests {
 
     [Fact]
     public void Evaluator_FunctionParameters_NoInfiniteLoop() {
-        // TODO doesn't throw when debugging, but does normally??
-        // need to debug the test
         var text = @"
             void hi(string name[=]) {
                 PrintLine(""Hi "" + name + ""!"");
@@ -552,7 +550,6 @@ public class EvaluatorTests {
             int PrintLine = 4;
             [PrintLine](""test"");
         ";
-        // TODO Maybe binder is skipping variables when going up the scopes to search for the function?
 
         var diagnostics = @"
             called object 'PrintLine' is not a function
@@ -708,7 +705,7 @@ public class EvaluatorTests {
 
     [Fact]
     public void Evaluator_DivideByZero_ThrowsException() {
-        // TODO need a way to assert exceptions
+        // TODO Need a way to assert exceptions
         var text = @"
             56/0;
         ";
@@ -778,7 +775,6 @@ public class EvaluatorTests {
 
         var tempDiagnostics = new BelteDiagnosticQueue();
 
-        // TODO currently all tests pass, but remind, does execution stop if parser has errors?
         if (syntaxTree.diagnostics.FilterOut(DiagnosticType.Warning).Any()) {
             tempDiagnostics.Move(syntaxTree.diagnostics);
         } else {

--- a/src/Buckle/Buckle/Buckle.csproj
+++ b/src/Buckle/Buckle/Buckle.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/Buckle/Buckle/Buckle.csproj
+++ b/src/Buckle/Buckle/Buckle.csproj
@@ -7,7 +7,7 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Repl</_Parameter1>
     </AssemblyAttribute>
-    <!-- TODO this still does not allow sander to see the internals during runtime -->
+    <!-- TODO This still does not allow sander to see the internals during runtime -->
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Sander</_Parameter1>
     </AssemblyAttribute>

--- a/src/Buckle/Buckle/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Binding/Binder.cs
@@ -919,7 +919,6 @@ internal sealed class Binder {
         } else {
             boundExpression = BindCast(nonNullableExpression, intermediateType);
             boundExpression = new BoundCastExpression(type, boundExpression);
-            // TODO What if diagnostics get added here? should never happen but if it does it will not be handled
         }
 
         return boundExpression;
@@ -1291,7 +1290,7 @@ internal sealed class Binder {
         /*
         <left> <op> <right>
 
-        TODO implement this operator
+        TODO Implement this operator
         ---> <op> is **
 
         {
@@ -1327,7 +1326,7 @@ internal sealed class Binder {
 
         var opResultType = tempOp.typeClause;
 
-        // TODO support is/isnt type statements
+        // TODO Support is/isnt type statements
         // E.g. 3 is int
         if (tempOp.opType == BoundBinaryOperatorType.Is || tempOp.opType == BoundBinaryOperatorType.Isnt) {
             /*

--- a/src/Buckle/Buckle/CodeAnalysis/Binding/BoundExpressionTypes.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Binding/BoundExpressionTypes.cs
@@ -348,7 +348,7 @@ internal sealed class BoundLiteralExpression : BoundExpression {
             typeClause = new BoundTypeClause(TypeSymbol.Int, isLiteral: true);
         else if (value is string)
             typeClause = new BoundTypeClause(TypeSymbol.String, isLiteral: true);
-        else if (value is float)
+        else if (value is decimal)
             typeClause = new BoundTypeClause(TypeSymbol.Decimal, isLiteral: true);
         else if (value == null)
             typeClause = new BoundTypeClause(null, isLiteral: true);

--- a/src/Buckle/Buckle/CodeAnalysis/Binding/BoundExpressionTypes.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Binding/BoundExpressionTypes.cs
@@ -348,7 +348,7 @@ internal sealed class BoundLiteralExpression : BoundExpression {
             typeClause = new BoundTypeClause(TypeSymbol.Int, isLiteral: true);
         else if (value is string)
             typeClause = new BoundTypeClause(TypeSymbol.String, isLiteral: true);
-        else if (value is decimal)
+        else if (value is double)
             typeClause = new BoundTypeClause(TypeSymbol.Decimal, isLiteral: true);
         else if (value == null)
             typeClause = new BoundTypeClause(null, isLiteral: true);
@@ -510,7 +510,6 @@ internal sealed class BoundInitializerListExpression : BoundExpression {
 
     internal override BoundNodeType type => BoundNodeType.LiteralExpression;
 
-    // TODO Consider factoring out this mass copy into a static method
     // Immutable design makes this required
     internal override BoundTypeClause typeClause => new BoundTypeClause(
         itemType.lType, itemType.isImplicit, itemType.isConstantReference,

--- a/src/Buckle/Buckle/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Binding/BoundScope.cs
@@ -81,7 +81,7 @@ internal sealed class BoundScope {
     /// <returns>If the symbol was found and successfully updated</returns>
     internal bool TryModifySymbol(string name, Symbol newSymbol) {
         // Does not work with overloads
-        // TODO need to allow overloads, as someone may try to define overloads for a nested function
+        // TODO Need to allow overloads, as someone may try to define overloads for a nested function
         var symbol = LookupSymbol(name);
 
         if (symbol == null)

--- a/src/Buckle/Buckle/CodeAnalysis/Binding/BoundTypes.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Binding/BoundTypes.cs
@@ -179,8 +179,8 @@ internal sealed class BoundTypeClause : BoundNode {
     /// </summary>
     internal bool isConstant { get; }
 
-    // TODO Figure out if all code can avoid using set
     // ! Use NonNullable and Nullable methods whenever possible
+    // Only nullable because making it immutable is more convoluted then allowing a couple exceptions
     /// <summary>
     /// If the value this type is referring to can be null.
     /// </summary>

--- a/src/Buckle/Buckle/CodeAnalysis/Binding/ConstantFolding.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Binding/ConstantFolding.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Numerics;
 using Buckle.CodeAnalysis.Symbols;
+using Buckle.Utils;
 
 namespace Buckle.CodeAnalysis.Binding;
 
@@ -49,16 +51,16 @@ internal static class ConstantFolding {
             rightValue = Convert.ToBoolean(rightValue);
         } else if (leftType == TypeSymbol.Int) {
             // Prevents bankers rounding from Convert.ToInt32, instead always truncate (no rounding)
-            if (leftValue is decimal)
-                leftValue = Math.Truncate((decimal)leftValue);
-            if (rightValue is decimal)
-                rightValue = Math.Truncate((decimal)rightValue);
+            if (leftValue.IsFloatingPoint())
+                leftValue = Math.Truncate(Convert.ToDouble(leftValue));
+            if (rightValue.IsFloatingPoint())
+                rightValue = Math.Truncate(Convert.ToDouble(rightValue));
 
             leftValue = Convert.ToInt32(leftValue);
             rightValue = Convert.ToInt32(rightValue);
         } else if (leftType == TypeSymbol.Decimal) {
-            leftValue = Convert.ToDecimal(leftValue);
-            rightValue = Convert.ToDecimal(rightValue);
+            leftValue = Convert.ToDouble(leftValue);
+            rightValue = Convert.ToDouble(rightValue);
         } else if (leftType == TypeSymbol.String) {
             leftValue = Convert.ToString(leftValue);
             rightValue = Convert.ToString(rightValue);
@@ -71,24 +73,24 @@ internal static class ConstantFolding {
                 else if (leftType == TypeSymbol.String)
                     return new BoundConstant((string)leftValue + (string)rightValue);
                 else
-                    return new BoundConstant((decimal)leftValue + (decimal)rightValue);
+                    return new BoundConstant((double)leftValue + (double)rightValue);
             case BoundBinaryOperatorType.Subtraction:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue - (int)rightValue);
                 else
-                    return new BoundConstant((decimal)leftValue - (decimal)rightValue);
+                    return new BoundConstant((double)leftValue - (double)rightValue);
             case BoundBinaryOperatorType.Multiplication:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue * (int)rightValue);
                 else
-                    return new BoundConstant((decimal)leftValue * (decimal)rightValue);
+                    return new BoundConstant((double)leftValue * (double)rightValue);
             case BoundBinaryOperatorType.Division:
                 if (leftType == TypeSymbol.Int) {
                     if ((int)rightValue != 0)
                         return new BoundConstant((int)leftValue / (int)rightValue);
                 } else {
-                    if ((decimal)rightValue != 0)
-                        return new BoundConstant((decimal)leftValue / (decimal)rightValue);
+                    if ((double)rightValue != 0)
+                        return new BoundConstant((double)leftValue / (double)rightValue);
                 }
 
                 return null;
@@ -96,7 +98,7 @@ internal static class ConstantFolding {
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)Math.Pow((int)leftValue, (int)rightValue));
                 else
-                    return new BoundConstant((decimal)Math.Pow((double)leftValue, (double)rightValue));
+                    return new BoundConstant((double)Math.Pow((double)leftValue, (double)rightValue));
             case BoundBinaryOperatorType.ConditionalAnd:
                 return new BoundConstant((bool)leftValue && (bool)rightValue);
             case BoundBinaryOperatorType.ConditionalOr:
@@ -109,22 +111,22 @@ internal static class ConstantFolding {
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue < (int)rightValue);
                 else
-                    return new BoundConstant((decimal)leftValue < (decimal)rightValue);
+                    return new BoundConstant((double)leftValue < (double)rightValue);
             case BoundBinaryOperatorType.GreaterThan:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue > (int)rightValue);
                 else
-                    return new BoundConstant((decimal)leftValue > (decimal)rightValue);
+                    return new BoundConstant((double)leftValue > (double)rightValue);
             case BoundBinaryOperatorType.LessOrEqual:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue <= (int)rightValue);
                 else
-                    return new BoundConstant((decimal)leftValue <= (decimal)rightValue);
+                    return new BoundConstant((double)leftValue <= (double)rightValue);
             case BoundBinaryOperatorType.GreatOrEqual:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue >= (int)rightValue);
                 else
-                    return new BoundConstant((decimal)leftValue >= (decimal)rightValue);
+                    return new BoundConstant((double)leftValue >= (double)rightValue);
             case BoundBinaryOperatorType.LogicalAnd:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue & (int)rightValue);
@@ -150,7 +152,7 @@ internal static class ConstantFolding {
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue % (int)rightValue);
                 else
-                    return new BoundConstant((decimal)leftValue % (decimal)rightValue);
+                    return new BoundConstant((double)leftValue % (double)rightValue);
             default:
                 throw new Exception($"Fold: unexpected binary operator '{op.opType}'");
         }
@@ -171,12 +173,12 @@ internal static class ConstantFolding {
                     if (operandType == TypeSymbol.Int)
                         return new BoundConstant((int)operand.constantValue.value);
                     else
-                        return new BoundConstant((decimal)operand.constantValue.value);
+                        return new BoundConstant((double)operand.constantValue.value);
                 case BoundUnaryOperatorType.NumericalNegation:
                     if (operandType == TypeSymbol.Int)
                         return new BoundConstant(-(int)operand.constantValue.value);
                     else
-                        return new BoundConstant(-(decimal)operand.constantValue.value);
+                        return new BoundConstant(-(double)operand.constantValue.value);
                 case BoundUnaryOperatorType.BooleanNegation:
                     return new BoundConstant(!(bool)operand.constantValue.value);
                 case BoundUnaryOperatorType.BitwiseCompliment:

--- a/src/Buckle/Buckle/CodeAnalysis/Binding/ConstantFolding.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Binding/ConstantFolding.cs
@@ -49,16 +49,16 @@ internal static class ConstantFolding {
             rightValue = Convert.ToBoolean(rightValue);
         } else if (leftType == TypeSymbol.Int) {
             // Prevents bankers rounding from Convert.ToInt32, instead always truncate (no rounding)
-            if (leftValue is Single)
-                leftValue = Math.Truncate((Single)leftValue);
-            if (rightValue is Single)
-                rightValue = Math.Truncate((Single)rightValue);
+            if (leftValue is decimal)
+                leftValue = Math.Truncate((decimal)leftValue);
+            if (rightValue is decimal)
+                rightValue = Math.Truncate((decimal)rightValue);
 
             leftValue = Convert.ToInt32(leftValue);
             rightValue = Convert.ToInt32(rightValue);
         } else if (leftType == TypeSymbol.Decimal) {
-            leftValue = Convert.ToSingle(leftValue);
-            rightValue = Convert.ToSingle(rightValue);
+            leftValue = Convert.ToDecimal(leftValue);
+            rightValue = Convert.ToDecimal(rightValue);
         } else if (leftType == TypeSymbol.String) {
             leftValue = Convert.ToString(leftValue);
             rightValue = Convert.ToString(rightValue);
@@ -71,24 +71,24 @@ internal static class ConstantFolding {
                 else if (leftType == TypeSymbol.String)
                     return new BoundConstant((string)leftValue + (string)rightValue);
                 else
-                    return new BoundConstant((float)leftValue + (float)rightValue);
+                    return new BoundConstant((decimal)leftValue + (decimal)rightValue);
             case BoundBinaryOperatorType.Subtraction:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue - (int)rightValue);
                 else
-                    return new BoundConstant((float)leftValue - (float)rightValue);
+                    return new BoundConstant((decimal)leftValue - (decimal)rightValue);
             case BoundBinaryOperatorType.Multiplication:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue * (int)rightValue);
                 else
-                    return new BoundConstant((float)leftValue * (float)rightValue);
+                    return new BoundConstant((decimal)leftValue * (decimal)rightValue);
             case BoundBinaryOperatorType.Division:
                 if (leftType == TypeSymbol.Int) {
                     if ((int)rightValue != 0)
                         return new BoundConstant((int)leftValue / (int)rightValue);
                 } else {
-                    if ((float)rightValue != 0)
-                        return new BoundConstant((float)leftValue / (float)rightValue);
+                    if ((decimal)rightValue != 0)
+                        return new BoundConstant((decimal)leftValue / (decimal)rightValue);
                 }
 
                 return null;
@@ -96,7 +96,7 @@ internal static class ConstantFolding {
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)Math.Pow((int)leftValue, (int)rightValue));
                 else
-                    return new BoundConstant((float)Math.Pow((float)leftValue, (float)rightValue));
+                    return new BoundConstant((decimal)Math.Pow((double)leftValue, (double)rightValue));
             case BoundBinaryOperatorType.ConditionalAnd:
                 return new BoundConstant((bool)leftValue && (bool)rightValue);
             case BoundBinaryOperatorType.ConditionalOr:
@@ -109,22 +109,22 @@ internal static class ConstantFolding {
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue < (int)rightValue);
                 else
-                    return new BoundConstant((float)leftValue < (float)rightValue);
+                    return new BoundConstant((decimal)leftValue < (decimal)rightValue);
             case BoundBinaryOperatorType.GreaterThan:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue > (int)rightValue);
                 else
-                    return new BoundConstant((float)leftValue > (float)rightValue);
+                    return new BoundConstant((decimal)leftValue > (decimal)rightValue);
             case BoundBinaryOperatorType.LessOrEqual:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue <= (int)rightValue);
                 else
-                    return new BoundConstant((float)leftValue <= (float)rightValue);
+                    return new BoundConstant((decimal)leftValue <= (decimal)rightValue);
             case BoundBinaryOperatorType.GreatOrEqual:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue >= (int)rightValue);
                 else
-                    return new BoundConstant((float)leftValue >= (float)rightValue);
+                    return new BoundConstant((decimal)leftValue >= (decimal)rightValue);
             case BoundBinaryOperatorType.LogicalAnd:
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue & (int)rightValue);
@@ -150,7 +150,7 @@ internal static class ConstantFolding {
                 if (leftType == TypeSymbol.Int)
                     return new BoundConstant((int)leftValue % (int)rightValue);
                 else
-                    return new BoundConstant((float)leftValue % (float)rightValue);
+                    return new BoundConstant((decimal)leftValue % (decimal)rightValue);
             default:
                 throw new Exception($"Fold: unexpected binary operator '{op.opType}'");
         }
@@ -171,12 +171,12 @@ internal static class ConstantFolding {
                     if (operandType == TypeSymbol.Int)
                         return new BoundConstant((int)operand.constantValue.value);
                     else
-                        return new BoundConstant((float)operand.constantValue.value);
+                        return new BoundConstant((decimal)operand.constantValue.value);
                 case BoundUnaryOperatorType.NumericalNegation:
                     if (operandType == TypeSymbol.Int)
                         return new BoundConstant(-(int)operand.constantValue.value);
                     else
-                        return new BoundConstant(-(float)operand.constantValue.value);
+                        return new BoundConstant(-(decimal)operand.constantValue.value);
                 case BoundUnaryOperatorType.BooleanNegation:
                     return new BoundConstant(!(bool)operand.constantValue.value);
                 case BoundUnaryOperatorType.BitwiseCompliment:

--- a/src/Buckle/Buckle/CodeAnalysis/Binding/ControlFlowGraph.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Binding/ControlFlowGraph.cs
@@ -281,7 +281,6 @@ internal sealed class ControlFlowGraph {
                 }
             }
 
-            // TODO Test to make sure this works like the original goto implementation
             void Scan() {
                 foreach (var block in blocks) {
                     if (!block.incoming.Any()) {

--- a/src/Buckle/Buckle/CodeAnalysis/Compilation.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Compilation.cs
@@ -178,7 +178,6 @@ public sealed class Compilation {
         var eval = new Evaluator(program, variables);
         var evalResult = eval.Evaluate();
 
-        // TODO Hack to prevent repl overwriting text when user does not add line break, could probably be cleaner
         if (eval.hasPrint)
             Console.WriteLine();
 

--- a/src/Buckle/Buckle/CodeAnalysis/Emitting/Emitter.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Emitting/Emitter.cs
@@ -505,7 +505,7 @@ internal class Emitter {
     }
 
     private void EmitEmptyExpression(ILProcessor iLProcessor, BoundEmptyExpression expression) {
-        // TODO Breaks control flow
+        // TODO Breaks control flow, debug why this does not work
         // iLProcessor.Emit(OpCodes.Nop);
     }
 

--- a/src/Buckle/Buckle/CodeAnalysis/Emitting/Emitter.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Emitting/Emitter.cs
@@ -57,7 +57,7 @@ internal class Emitter {
             (TypeSymbol.Any, "System.Object"),
             (TypeSymbol.Bool, "System.Boolean"),
             (TypeSymbol.Int, "System.Int32"),
-            (TypeSymbol.Decimal, "System.Single"),
+            (TypeSymbol.Decimal, "System.Decimal"),
             (TypeSymbol.String, "System.String"),
             (TypeSymbol.Void, "System.Void"),
         };
@@ -104,8 +104,8 @@ internal class Emitter {
                 NetMethodReference.ConvertToString,
                 ResolveMethod("System.Convert", "ToString", new [] { "System.Object" })
             }, {
-                NetMethodReference.ConvertToSingle,
-                ResolveMethod("System.Convert", "ToSingle", new [] { "System.Object" })
+                NetMethodReference.ConvertToDecimal,
+                ResolveMethod("System.Convert", "ToDecimal", new [] { "System.Object" })
             }, {
                 NetMethodReference.ObjectEquals,
                 ResolveMethod("System.Object", "Equals", new [] { "System.Object", "System.Object" })
@@ -148,7 +148,7 @@ internal class Emitter {
         ConvertToBoolean,
         ConvertToInt32,
         ConvertToString,
-        ConvertToSingle,
+        ConvertToDecimal,
         ObjectEquals,
         RandomNext,
         RandomCtor,
@@ -556,7 +556,7 @@ internal class Emitter {
             else if (to.lType == TypeSymbol.String)
                 return methodReferences_[NetMethodReference.ConvertToString];
             else if (to.lType == TypeSymbol.Decimal)
-                return methodReferences_[NetMethodReference.ConvertToSingle];
+                return methodReferences_[NetMethodReference.ConvertToDecimal];
             else
                 throw new Exception($"GetConvertTo: unexpected cast from '{from}' to '{to}'");
         }

--- a/src/Buckle/Buckle/CodeAnalysis/Emitting/Emitter.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Emitting/Emitter.cs
@@ -57,7 +57,7 @@ internal class Emitter {
             (TypeSymbol.Any, "System.Object"),
             (TypeSymbol.Bool, "System.Boolean"),
             (TypeSymbol.Int, "System.Int32"),
-            (TypeSymbol.Decimal, "System.Decimal"),
+            (TypeSymbol.Decimal, "System.Double"),
             (TypeSymbol.String, "System.String"),
             (TypeSymbol.Void, "System.Void"),
         };
@@ -104,8 +104,8 @@ internal class Emitter {
                 NetMethodReference.ConvertToString,
                 ResolveMethod("System.Convert", "ToString", new [] { "System.Object" })
             }, {
-                NetMethodReference.ConvertToDecimal,
-                ResolveMethod("System.Convert", "ToDecimal", new [] { "System.Object" })
+                NetMethodReference.ConvertToDouble,
+                ResolveMethod("System.Convert", "ToDouble", new [] { "System.Object" })
             }, {
                 NetMethodReference.ObjectEquals,
                 ResolveMethod("System.Object", "Equals", new [] { "System.Object", "System.Object" })
@@ -148,7 +148,7 @@ internal class Emitter {
         ConvertToBoolean,
         ConvertToInt32,
         ConvertToString,
-        ConvertToDecimal,
+        ConvertToDouble,
         ObjectEquals,
         RandomNext,
         RandomCtor,
@@ -556,7 +556,7 @@ internal class Emitter {
             else if (to.lType == TypeSymbol.String)
                 return methodReferences_[NetMethodReference.ConvertToString];
             else if (to.lType == TypeSymbol.Decimal)
-                return methodReferences_[NetMethodReference.ConvertToDecimal];
+                return methodReferences_[NetMethodReference.ConvertToDouble];
             else
                 throw new Exception($"GetConvertTo: unexpected cast from '{from}' to '{to}'");
         }

--- a/src/Buckle/Buckle/CodeAnalysis/Emitting/EmitterOld.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Emitting/EmitterOld.cs
@@ -44,7 +44,7 @@ internal class _Emitter {
         ConvertToBoolean,
         ConvertToInt32,
         ConvertToString,
-        ConvertToDecimal,
+        ConvertToSingle,
         ObjectEquals,
         RandomNext,
         RandomCtor,
@@ -81,7 +81,7 @@ internal class _Emitter {
             (TypeSymbol.Any, "System.Object"),
             (TypeSymbol.Bool, "System.Boolean"),
             (TypeSymbol.Int, "System.Int32"),
-            (TypeSymbol.Decimal, "System.Decimal"),
+            (TypeSymbol.Decimal, "System.Single"),
             (TypeSymbol.String, "System.String"),
             (TypeSymbol.Void, "System.Void"),
         };
@@ -128,8 +128,8 @@ internal class _Emitter {
                 NetMethodReference.ConvertToString,
                 ResolveMethod("System.Convert", "ToString", new [] { "System.Object" })
             }, {
-                NetMethodReference.ConvertToDecimal,
-                ResolveMethod("System.Convert", "ToDecimal", new [] { "System.Object" })
+                NetMethodReference.ConvertToSingle,
+                ResolveMethod("System.Convert", "ToSingle", new [] { "System.Object" })
             }, {
                 NetMethodReference.ObjectEquals,
                 ResolveMethod("System.Object", "Equals", new [] { "System.Object", "System.Object" })
@@ -725,7 +725,7 @@ internal class _Emitter {
             else if (to.lType == TypeSymbol.String)
                 return methodReferences_[NetMethodReference.ConvertToString];
             else if (to.lType == TypeSymbol.Decimal)
-                return methodReferences_[NetMethodReference.ConvertToDecimal];
+                return methodReferences_[NetMethodReference.ConvertToSingle];
             else
                 throw new Exception($"GetConvertTo: unexpected cast from '{from}' to '{to}'");
         }
@@ -1043,7 +1043,6 @@ internal class _Emitter {
             var instruction = value ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0;
             iLProcessor.Emit(instruction);
         } else if (expressionType == TypeSymbol.Decimal) {
-            // TODO Change this to decimal type
             var value = Convert.ToSingle(expression.constantValue.value);
             iLProcessor.Emit(OpCodes.Ldc_R4, value);
         } else {

--- a/src/Buckle/Buckle/CodeAnalysis/Emitting/EmitterOld.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Emitting/EmitterOld.cs
@@ -44,7 +44,7 @@ internal class _Emitter {
         ConvertToBoolean,
         ConvertToInt32,
         ConvertToString,
-        ConvertToSingle,
+        ConvertToDecimal,
         ObjectEquals,
         RandomNext,
         RandomCtor,
@@ -81,7 +81,7 @@ internal class _Emitter {
             (TypeSymbol.Any, "System.Object"),
             (TypeSymbol.Bool, "System.Boolean"),
             (TypeSymbol.Int, "System.Int32"),
-            (TypeSymbol.Decimal, "System.Single"),
+            (TypeSymbol.Decimal, "System.Decimal"),
             (TypeSymbol.String, "System.String"),
             (TypeSymbol.Void, "System.Void"),
         };
@@ -128,8 +128,8 @@ internal class _Emitter {
                 NetMethodReference.ConvertToString,
                 ResolveMethod("System.Convert", "ToString", new [] { "System.Object" })
             }, {
-                NetMethodReference.ConvertToSingle,
-                ResolveMethod("System.Convert", "ToSingle", new [] { "System.Object" })
+                NetMethodReference.ConvertToDecimal,
+                ResolveMethod("System.Convert", "ToDecimal", new [] { "System.Object" })
             }, {
                 NetMethodReference.ObjectEquals,
                 ResolveMethod("System.Object", "Equals", new [] { "System.Object", "System.Object" })
@@ -725,7 +725,7 @@ internal class _Emitter {
             else if (to.lType == TypeSymbol.String)
                 return methodReferences_[NetMethodReference.ConvertToString];
             else if (to.lType == TypeSymbol.Decimal)
-                return methodReferences_[NetMethodReference.ConvertToSingle];
+                return methodReferences_[NetMethodReference.ConvertToDecimal];
             else
                 throw new Exception($"GetConvertTo: unexpected cast from '{from}' to '{to}'");
         }
@@ -1043,6 +1043,7 @@ internal class _Emitter {
             var instruction = value ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0;
             iLProcessor.Emit(instruction);
         } else if (expressionType == TypeSymbol.Decimal) {
+            // TODO Change this to decimal type
             var value = Convert.ToSingle(expression.constantValue.value);
             iLProcessor.Emit(OpCodes.Ldc_R4, value);
         } else {

--- a/src/Buckle/Buckle/CodeAnalysis/Emitting/EmitterOld.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Emitting/EmitterOld.cs
@@ -674,7 +674,6 @@ internal class _Emitter {
     }
 
     private void EmitEmptyExpression(ILProcessor iLProcessor, BoundEmptyExpression expression) {
-        // TODO Breaks control flow
         // iLProcessor.Emit(OpCodes.Nop);
     }
 

--- a/src/Buckle/Buckle/CodeAnalysis/Evaluator.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Evaluator.cs
@@ -190,12 +190,12 @@ internal sealed class Evaluator {
     }
 
     private object EvaluateTypeofExpression(BoundTypeofExpression node) {
-        // TODO implement typeof and type types
+        // TODO Implement typeof and type types
         return null;
     }
 
     private object EvaluateReferenceExpression(BoundReferenceExpression node) {
-        // TODO implement references in the Evaluator
+        // TODO Implement references in the Evaluator
         return null;
     }
 
@@ -374,37 +374,6 @@ internal sealed class Evaluator {
         var left = EvaluateExpression(syntax.left);
         var right = EvaluateExpression(syntax.right);
 
-        // TODO Treat comparison operators normally, `is` is the only operator that handles null comparing
-        // Comparison operators are the only operators that can work with null
-        switch (syntax.op.opType) {
-            case BoundBinaryOperatorType.EqualityEquals:
-                return Equals(left, right);
-            case BoundBinaryOperatorType.EqualityNotEquals:
-                return !Equals(left, right);
-            case BoundBinaryOperatorType.LessThan:
-                if (left == null || right == null)
-                    return false;
-
-                break;
-            case BoundBinaryOperatorType.GreaterThan:
-                if (left == null || right == null)
-                    return false;
-
-                break;
-            case BoundBinaryOperatorType.LessOrEqual:
-                if (left == null || right == null)
-                    return false;
-
-                break;
-            case BoundBinaryOperatorType.GreatOrEqual:
-                if (left == null || right == null)
-                    return false;
-
-                break;
-            default:
-                break;
-        }
-
         if (left == null || right == null)
             return null;
 
@@ -443,6 +412,10 @@ internal sealed class Evaluator {
                 return (bool)left && (bool)right;
             case BoundBinaryOperatorType.ConditionalOr:
                 return (bool)left || (bool)right;
+            case BoundBinaryOperatorType.EqualityEquals:
+                return Equals(left, right);
+            case BoundBinaryOperatorType.EqualityNotEquals:
+                return !Equals(left, right);
             case BoundBinaryOperatorType.LessThan:
                 if (leftType == TypeSymbol.Int)
                     return (int)left < (int)right;

--- a/src/Buckle/Buckle/CodeAnalysis/Evaluator.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Evaluator.cs
@@ -233,14 +233,14 @@ internal sealed class Evaluator {
         } else if (type == TypeSymbol.Bool) {
             return Convert.ToBoolean(value);
         } else if (type == TypeSymbol.Int) {
-            if (value is Single)
-                value = Math.Truncate((Single)value);
+            if (value is decimal)
+                value = Math.Truncate((decimal)value);
 
             return Convert.ToInt32(value);
         } else if (type == TypeSymbol.String) {
             return Convert.ToString(value);
         } else if (type == TypeSymbol.Decimal) {
-            return Convert.ToSingle(value);
+            return Convert.ToDecimal(value);
         }
 
         throw new Exception($"EvaluateCast: unexpected type '{typeClause}'");
@@ -354,12 +354,12 @@ internal sealed class Evaluator {
                 if (syntax.operand.typeClause.lType == TypeSymbol.Int)
                     return (int)operand;
                 else
-                    return (float)operand;
+                    return (decimal)operand;
             case BoundUnaryOperatorType.NumericalNegation:
                 if (syntax.operand.typeClause.lType == TypeSymbol.Int)
                     return -(int)operand;
                 else
-                    return -(float)operand;
+                    return -(decimal)operand;
             case BoundUnaryOperatorType.BooleanNegation:
                 return !(bool)operand;
             case BoundUnaryOperatorType.BitwiseCompliment:
@@ -417,27 +417,27 @@ internal sealed class Evaluator {
                 else if (syntaxType == TypeSymbol.String)
                     return (string)left + (string)right;
                 else
-                    return (float)left + (float)right;
+                    return (decimal)left + (decimal)right;
             case BoundBinaryOperatorType.Subtraction:
                 if (syntaxType == TypeSymbol.Int)
                     return (int)left - (int)right;
                 else
-                    return (float)left - (float)right;
+                    return (decimal)left - (decimal)right;
             case BoundBinaryOperatorType.Multiplication:
                 if (syntaxType == TypeSymbol.Int)
                     return (int)left * (int)right;
                 else
-                    return (float)left * (float)right;
+                    return (decimal)left * (decimal)right;
             case BoundBinaryOperatorType.Division:
                 if (syntaxType == TypeSymbol.Int)
                     return (int)left / (int)right;
                 else
-                    return (float)left / (float)right;
+                    return (decimal)left / (decimal)right;
             case BoundBinaryOperatorType.Power:
                 if (syntaxType == TypeSymbol.Int)
                     return (int)Math.Pow((int)left, (int)right);
                 else
-                    return (float)Math.Pow((float)left, (float)right);
+                    return (decimal)Math.Pow((double)left, (double)right);
             case BoundBinaryOperatorType.ConditionalAnd:
                 return (bool)left && (bool)right;
             case BoundBinaryOperatorType.ConditionalOr:
@@ -446,22 +446,22 @@ internal sealed class Evaluator {
                 if (leftType == TypeSymbol.Int)
                     return (int)left < (int)right;
                 else
-                    return (float)left < (float)right;
+                    return (decimal)left < (decimal)right;
             case BoundBinaryOperatorType.GreaterThan:
                 if (leftType == TypeSymbol.Int)
                     return (int)left > (int)right;
                 else
-                    return (float)left > (float)right;
+                    return (decimal)left > (decimal)right;
             case BoundBinaryOperatorType.LessOrEqual:
                 if (leftType == TypeSymbol.Int)
                     return (int)left <= (int)right;
                 else
-                    return (float)left <= (float)right;
+                    return (decimal)left <= (decimal)right;
             case BoundBinaryOperatorType.GreatOrEqual:
                 if (leftType == TypeSymbol.Int)
                     return (int)left >= (int)right;
                 else
-                    return (float)left >= (float)right;
+                    return (decimal)left >= (decimal)right;
             case BoundBinaryOperatorType.LogicalAnd:
                 if (syntaxType == TypeSymbol.Int)
                     return (int)left & (int)right;
@@ -487,7 +487,7 @@ internal sealed class Evaluator {
                 if (syntaxType == TypeSymbol.Int)
                     return (int)left % (int)right;
                 else
-                    return (float)left % (float)right;
+                    return (decimal)left % (decimal)right;
             default:
                 throw new Exception($"EvaluateBinaryExpression: unknown binary operator '{syntax.op}'");
         }

--- a/src/Buckle/Buckle/CodeAnalysis/Evaluator.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Evaluator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Buckle.Diagnostics;
 using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.Symbols;
+using Buckle.Utils;
 
 namespace Buckle.CodeAnalysis;
 
@@ -233,14 +234,14 @@ internal sealed class Evaluator {
         } else if (type == TypeSymbol.Bool) {
             return Convert.ToBoolean(value);
         } else if (type == TypeSymbol.Int) {
-            if (value is decimal)
-                value = Math.Truncate((decimal)value);
+            if (value.IsFloatingPoint())
+                value = Math.Truncate(Convert.ToDouble(value));
 
             return Convert.ToInt32(value);
         } else if (type == TypeSymbol.String) {
             return Convert.ToString(value);
         } else if (type == TypeSymbol.Decimal) {
-            return Convert.ToDecimal(value);
+            return Convert.ToDouble(value);
         }
 
         throw new Exception($"EvaluateCast: unexpected type '{typeClause}'");
@@ -354,12 +355,12 @@ internal sealed class Evaluator {
                 if (syntax.operand.typeClause.lType == TypeSymbol.Int)
                     return (int)operand;
                 else
-                    return (decimal)operand;
+                    return (double)operand;
             case BoundUnaryOperatorType.NumericalNegation:
                 if (syntax.operand.typeClause.lType == TypeSymbol.Int)
                     return -(int)operand;
                 else
-                    return -(decimal)operand;
+                    return -(double)operand;
             case BoundUnaryOperatorType.BooleanNegation:
                 return !(bool)operand;
             case BoundUnaryOperatorType.BitwiseCompliment:
@@ -417,27 +418,27 @@ internal sealed class Evaluator {
                 else if (syntaxType == TypeSymbol.String)
                     return (string)left + (string)right;
                 else
-                    return (decimal)left + (decimal)right;
+                    return (double)left + (double)right;
             case BoundBinaryOperatorType.Subtraction:
                 if (syntaxType == TypeSymbol.Int)
                     return (int)left - (int)right;
                 else
-                    return (decimal)left - (decimal)right;
+                    return (double)left - (double)right;
             case BoundBinaryOperatorType.Multiplication:
                 if (syntaxType == TypeSymbol.Int)
                     return (int)left * (int)right;
                 else
-                    return (decimal)left * (decimal)right;
+                    return (double)left * (double)right;
             case BoundBinaryOperatorType.Division:
                 if (syntaxType == TypeSymbol.Int)
                     return (int)left / (int)right;
                 else
-                    return (decimal)left / (decimal)right;
+                    return (double)left / (double)right;
             case BoundBinaryOperatorType.Power:
                 if (syntaxType == TypeSymbol.Int)
                     return (int)Math.Pow((int)left, (int)right);
                 else
-                    return (decimal)Math.Pow((double)left, (double)right);
+                    return (double)Math.Pow((double)left, (double)right);
             case BoundBinaryOperatorType.ConditionalAnd:
                 return (bool)left && (bool)right;
             case BoundBinaryOperatorType.ConditionalOr:
@@ -446,22 +447,22 @@ internal sealed class Evaluator {
                 if (leftType == TypeSymbol.Int)
                     return (int)left < (int)right;
                 else
-                    return (decimal)left < (decimal)right;
+                    return (double)left < (double)right;
             case BoundBinaryOperatorType.GreaterThan:
                 if (leftType == TypeSymbol.Int)
                     return (int)left > (int)right;
                 else
-                    return (decimal)left > (decimal)right;
+                    return (double)left > (double)right;
             case BoundBinaryOperatorType.LessOrEqual:
                 if (leftType == TypeSymbol.Int)
                     return (int)left <= (int)right;
                 else
-                    return (decimal)left <= (decimal)right;
+                    return (double)left <= (double)right;
             case BoundBinaryOperatorType.GreatOrEqual:
                 if (leftType == TypeSymbol.Int)
                     return (int)left >= (int)right;
                 else
-                    return (decimal)left >= (decimal)right;
+                    return (double)left >= (double)right;
             case BoundBinaryOperatorType.LogicalAnd:
                 if (syntaxType == TypeSymbol.Int)
                     return (int)left & (int)right;
@@ -487,7 +488,7 @@ internal sealed class Evaluator {
                 if (syntaxType == TypeSymbol.Int)
                     return (int)left % (int)right;
                 else
-                    return (decimal)left % (decimal)right;
+                    return (double)left % (double)right;
             default:
                 throw new Exception($"EvaluateBinaryExpression: unknown binary operator '{syntax.op}'");
         }

--- a/src/Buckle/Buckle/CodeAnalysis/Symbols/Primitives.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Symbols/Primitives.cs
@@ -16,7 +16,7 @@ internal class TypeSymbol : Symbol {
     internal static readonly TypeSymbol Int = new TypeSymbol("int");
 
     /// <summary>
-    /// Decimal type (any decimal number, precision TBD).
+    /// Decimal type (any floating point number, precision TBD).
     /// </summary>
     internal static readonly TypeSymbol Decimal = new TypeSymbol("decimal");
 

--- a/src/Buckle/Buckle/CodeAnalysis/Syntax/ExpressionTypes.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Syntax/ExpressionTypes.cs
@@ -326,7 +326,7 @@ internal sealed partial class ReferenceExpression : Expression {
     internal override SyntaxType type => SyntaxType.REFERENCE_EXPRESSION;
 }
 
-// TODO make sure that block statements can still have return statements (they might)
+// TODO Make sure that block statements can still have return statements (they might)
 /// <summary>
 /// Inline function expression, similar to local function but is evaluated immediately and has no signature.
 /// E.g. { ... statements (including a return statement) ... }

--- a/src/Buckle/Buckle/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Syntax/Lexer.cs
@@ -85,7 +85,7 @@ internal sealed class Lexer {
                     break;
                 case '/':
                     if (lookahead == '/')
-                        // TODO Docstring comments (xml or doxygen)
+                        // TODO Docstring comments (xml/doxygen, probably xml)
                         ReadSingeLineComment();
                     else if (lookahead == '*')
                         ReadMultiLineComment();
@@ -512,7 +512,7 @@ internal sealed class Lexer {
                 value_ = value;
             }
         } else {
-            if (!decimal.TryParse(text, out var value)) {
+            if (!double.TryParse(text, out var value)) {
                 var span = new TextSpan(start_, length);
                 var location = new TextLocation(text_, span);
                 diagnostics.Push(Error.InvalidType(location, text, TypeSymbol.Int));

--- a/src/Buckle/Buckle/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Syntax/Lexer.cs
@@ -512,7 +512,7 @@ internal sealed class Lexer {
                 value_ = value;
             }
         } else {
-            if (!float.TryParse(text, out var value)) {
+            if (!decimal.TryParse(text, out var value)) {
                 var span = new TextSpan(start_, length);
                 var location = new TextLocation(text_, span);
                 diagnostics.Push(Error.InvalidType(location, text, TypeSymbol.Int));

--- a/src/Buckle/Buckle/CodeAnalysis/Syntax/Parser.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Syntax/Parser.cs
@@ -245,7 +245,6 @@ internal sealed class Parser {
             var expression = ParseParameter();
             nodesAndSeparators.Add(expression);
 
-            // TODO Optional parameters
             if (current.type == SyntaxType.COMMA_TOKEN) {
                 var comma = Next();
                 nodesAndSeparators.Add(comma);

--- a/src/Buckle/Buckle/IO/TextWriterExtensions.cs
+++ b/src/Buckle/Buckle/IO/TextWriterExtensions.cs
@@ -5,7 +5,7 @@ using Buckle.CodeAnalysis.Syntax;
 
 namespace Buckle.IO;
 
-// TODO use REPL color themes instead of hard coding colors
+// TODO Use REPL color themes instead of hard coding colors
 /// <summary>
 /// Extensions for the TextWriter object, writes text with predefined colors.
 /// </summary>

--- a/src/Buckle/Buckle/Preprocessor.cs
+++ b/src/Buckle/Buckle/Preprocessor.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Buckle.CodeAnalysis.Text;
 
-// TODO finish preprocessor
 // * Needs to use the lexer, parser, and constant evaluator to evaluate statements like #run, #if, #elif, and #define
 
 namespace Buckle;

--- a/src/Buckle/Diagnostics/Diagnostics.csproj
+++ b/src/Buckle/Diagnostics/Diagnostics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>annotations</Nullable>
   </PropertyGroup>

--- a/src/Buckle/Repl/BelteRepl.cs
+++ b/src/Buckle/Repl/BelteRepl.cs
@@ -9,6 +9,9 @@ using Diagnostics;
 
 namespace Repl;
 
+/// <summary>
+/// Uses framework from ReplBase and adds syntax highlighting and evaluation.
+/// </summary>
 public sealed class BelteRepl : ReplBase {
     private static readonly Compilation emptyCompilation = Compilation.CreateScript(null);
     private Dictionary<string, ColorTheme> InUse = new Dictionary<string, ColorTheme>() {
@@ -261,7 +264,6 @@ public sealed class BelteRepl : ReplBase {
     }
 
     private void LoadSubmissions() {
-        // TODO Make console handle null so evaluator does not print output?
         var files = Directory.GetFiles(GetSubmissionsDirectory()).OrderBy(f => f).ToArray();
         var keyword = files.Length == 1 ? "submission" : "submissions";
         Console.Out.WritePunctuation($"loaded {files.Length} {keyword}");

--- a/src/Buckle/Repl/Repl.cs
+++ b/src/Buckle/Repl/Repl.cs
@@ -6,7 +6,6 @@ using Buckle;
 using Buckle.Diagnostics;
 
 namespace Repl;
-// TODO crashes when fill a line completely
 
 /// <summary>
 /// Overrides default console handling and controls all keystrokes. Adds framework for meta commands and submissions.
@@ -94,7 +93,7 @@ public abstract class ReplBase {
     /// Reloads REPL to start accepting submissions again.
     /// </summary>
     internal void ReviveDocument() {
-        // TODO redisplay previous submissions
+        // TODO Redisplay previous submissions
         Console.Clear();
     }
 

--- a/src/Buckle/Repl/Repl.csproj
+++ b/src/Buckle/Repl/Repl.csproj
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>annotations</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
- Removed casting in unit test InlineData attributes
- Upgraded to use .NET 7.0
- Modified compiler to use System.Double instead of System.Single as the C# equivalent to the decimal data type
  Played around with using the System.Decimal type, but since primitives are temporary it does not matter a lot, opted for speed over precision
- Updated some capitalization in comments, and removed old TODO's and converted some to Trello cards