### PR TITLE
Rw/cleanup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,10 @@
             //     "samples/Hello",
             //     "-o samples/Hello/obj/Debug/netcoreapp3.1/Hello.dll"
             // ],
+            // "args": [
+            //     "-i",
+            //     "test.ble"
+            // ],
             "args": ["-r"],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",

--- a/src/Buckle/Belte/CommandLine/CommandLine.cs
+++ b/src/Buckle/Belte/CommandLine/CommandLine.cs
@@ -22,8 +22,9 @@ public static partial class BuckleCommandLine {
     private const int FatalExitCode = 2;
 
     private static readonly string[] AllowedOptions = {
-        // TODO Add W options
-        // "error", "ignore", "all"
+        "error",    // Treats all warnings as errors
+        "ignore",   // Ignores all warnings
+        "all"       // Shows additional warnings, and shows warnings while interpreting
     };
 
     /// <summary>
@@ -33,7 +34,7 @@ public static partial class BuckleCommandLine {
     /// <returns>Error code, 0 = success.</returns>
     public static int ProcessArgs(string[] args) {
         int err;
-        Compiler compiler = new Compiler();
+        Compiler compiler = new Compiler(ResolveDiagnostics);
         compiler.me = Process.GetCurrentProcess().ProcessName;
 
         compiler.state = DecodeOptions(
@@ -46,7 +47,7 @@ public static partial class BuckleCommandLine {
 
         if (!Directory.Exists(resources)) {
             corrupt = true;
-            ResolveDiagnostic(Belte.Diagnostics.Warning.CorruptInstallation(), compiler.me);
+            ResolveDiagnostic(Belte.Diagnostics.Warning.CorruptInstallation(), compiler.me, compiler.state.options);
         }
 
         if (hasDialog)
@@ -67,11 +68,11 @@ public static partial class BuckleCommandLine {
         }
 
         if (hasDialog) {
-            ResolveDiagnostics(diagnostics, compiler.me);
+            ResolveDiagnostics(diagnostics, compiler.me, compiler.state.options);
             return SuccessExitCode;
         }
 
-        err = ResolveDiagnostics(diagnostics, compiler.me);
+        err = ResolveDiagnostics(diagnostics, compiler.me, compiler.state.options);
 
         if (err > 0)
             return err;
@@ -79,7 +80,7 @@ public static partial class BuckleCommandLine {
         ResolveOutputFiles(compiler);
         ReadInputFiles(compiler, out diagnostics);
 
-        err = ResolveDiagnostics(diagnostics, compiler.me);
+        err = ResolveDiagnostics(diagnostics, compiler.me, compiler.state.options);
 
         if (err > 0)
             return err;
@@ -194,7 +195,7 @@ public static partial class BuckleCommandLine {
         Console.WriteLine(versionMessage);
     }
 
-    private static void PrettyPrintDiagnostic(BelteDiagnostic diagnostic, ConsoleColor? textColor) {
+    private static void PrettyPrintDiagnostic(BelteDiagnostic diagnostic, ConsoleColor? textColor, string[] options) {
         void ResetColor() {
             if (textColor != null)
                 Console.ForegroundColor = textColor.Value;
@@ -218,15 +219,20 @@ public static partial class BuckleCommandLine {
 
         ConsoleColor highlightColor = ConsoleColor.White;
 
-        if (diagnostic.info.severity == DiagnosticType.Error) {
+        var severity = diagnostic.info.severity;
+
+        if (severity == DiagnosticType.Warning && options.Contains("error"))
+            severity = DiagnosticType.Error;
+
+        if (severity == DiagnosticType.Error) {
             highlightColor = ConsoleColor.Red;
             Console.ForegroundColor = highlightColor;
             Console.Write(" error");
-        } else if (diagnostic.info.severity == DiagnosticType.Fatal) {
+        } else if (severity == DiagnosticType.Fatal) {
             highlightColor = ConsoleColor.Red;
             Console.ForegroundColor = highlightColor;
             Console.Write(" fatal error");
-        } else if (diagnostic.info.severity == DiagnosticType.Warning) {
+        } else if (severity == DiagnosticType.Warning) {
             highlightColor = ConsoleColor.Magenta;
             Console.ForegroundColor = highlightColor;
             Console.Write(" warning");
@@ -276,7 +282,7 @@ public static partial class BuckleCommandLine {
     }
 
     private static DiagnosticType ResolveDiagnostic<Type>(
-        Type diagnostic, string me, ConsoleColor? textColor = null)
+        Type diagnostic, string me, string[] options, ConsoleColor? textColor = null)
         where Type : Diagnostic {
         ConsoleColor previous = Console.ForegroundColor;
 
@@ -287,19 +293,26 @@ public static partial class BuckleCommandLine {
                 Console.ResetColor();
         }
 
+        var severity = diagnostic.info.severity;
+
+        if (severity == DiagnosticType.Warning && options.Contains("error"))
+            severity = DiagnosticType.Error;
+        if (severity == DiagnosticType.Warning && options.Contains("ignore"))
+            severity = DiagnosticType.Unknown;
+
         ResetColor();
 
-        if (diagnostic.info.severity == DiagnosticType.Unknown) {
+        if (severity == DiagnosticType.Unknown) {
         } else if (diagnostic.info.module != "BU" || (diagnostic is BelteDiagnostic bd && bd.location == null)) {
             Console.Write($"{me}: ");
 
-            if (diagnostic.info.severity == DiagnosticType.Warning) {
+            if (severity == DiagnosticType.Warning) {
                 Console.ForegroundColor = ConsoleColor.Magenta;
                 Console.Write("warning ");
-            } else if (diagnostic.info.severity == DiagnosticType.Error) {
+            } else if (severity == DiagnosticType.Error) {
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.Write("error ");
-            } else if (diagnostic.info.severity == DiagnosticType.Fatal) {
+            } else if (severity == DiagnosticType.Fatal) {
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.Write("fatal error ");
             }
@@ -311,15 +324,15 @@ public static partial class BuckleCommandLine {
             ResetColor();
             Console.WriteLine(diagnostic.message);
         } else {
-            PrettyPrintDiagnostic(diagnostic as BelteDiagnostic, textColor);
+            PrettyPrintDiagnostic(diagnostic as BelteDiagnostic, textColor, options);
         }
 
         Console.ForegroundColor = previous;
-        return diagnostic.info.severity;
+        return severity;
     }
 
     private static int ResolveDiagnostics<Type>(
-        DiagnosticQueue<Type> diagnostics, string me, ConsoleColor? textColor = null)
+        DiagnosticQueue<Type> diagnostics, string me, string[] options, ConsoleColor? textColor = null)
         where Type : Diagnostic {
         if (diagnostics.count == 0)
             return SuccessExitCode;
@@ -328,7 +341,7 @@ public static partial class BuckleCommandLine {
         Diagnostic diagnostic = diagnostics.Pop();
 
         while (diagnostic != null) {
-            DiagnosticType temp = ResolveDiagnostic(diagnostic, me, textColor);
+            DiagnosticType temp = ResolveDiagnostic(diagnostic, me, options, textColor);
 
             switch (temp) {
                 case DiagnosticType.Warning:
@@ -361,9 +374,13 @@ public static partial class BuckleCommandLine {
         }
     }
 
+    private static int ResolveDiagnostics(Compiler compiler) {
+        return ResolveDiagnostics(compiler, null);
+    }
+
     private static int ResolveDiagnostics(
         Compiler compiler, string me = null, ConsoleColor textColor = ConsoleColor.White) {
-        return ResolveDiagnostics(compiler.diagnostics, me ?? compiler.me, textColor);
+        return ResolveDiagnostics(compiler.diagnostics, me ?? compiler.me, compiler.state.options, textColor);
     }
 
     private static void ProduceOutputFiles(Compiler compiler) {

--- a/src/Buckle/Buckle.Generators/CurlyIndentor.cs
+++ b/src/Buckle/Buckle.Generators/CurlyIndentor.cs
@@ -6,7 +6,7 @@ namespace Buckle.Generators;
 /// <summary>
 /// Keeps track of a new curly brace enclosed scope.
 /// </summary>
-internal class CurlyIndenter : IDisposable {
+internal sealed class CurlyIndenter : IDisposable {
     private IndentedTextWriter _indentedTextWriter;
 
     /// <summary>

--- a/src/Buckle/Buckle.Generators/GetChildrenGenerator.cs
+++ b/src/Buckle/Buckle.Generators/GetChildrenGenerator.cs
@@ -33,10 +33,12 @@ public class GetChildrenGenerator : ISourceGenerator {
         var immutableArrayType = compilation.GetTypeByMetadataName("System.Collections.Immutable.ImmutableArray`1");
         var separatedSyntaxListType =
             compilation.GetTypeByMetadataName("Buckle.CodeAnalysis.Syntax.SeparatedSyntaxList`1");
+        var syntaxListType =
+            compilation.GetTypeByMetadataName("Buckle.CodeAnalysis.Syntax.SyntaxList`1");
         var nodeType = compilation.GetTypeByMetadataName("Buckle.CodeAnalysis.Syntax.Node");
         var nodeTypes = types.Where(t => !t.IsAbstract && IsDerivedFrom(t, nodeType) && IsPartial(t));
 
-        if (immutableArrayType == null || separatedSyntaxListType == null || nodeType == null)
+        if (immutableArrayType == null || separatedSyntaxListType == null || nodeType == null || syntaxListType == null)
             return;
 
         string indentString = "    ";
@@ -78,6 +80,11 @@ public class GetChildrenGenerator : ISourceGenerator {
                                 IsDerivedFrom(propertyType.TypeArguments[0], nodeType)) {
                                 indentedTextWriter.WriteLine(
                                     $"foreach (var child in {property.Name}.GetWithSeparators())");
+                                indentedTextWriter.WriteLine($"{indentString}yield return child;");
+                            } else if (SymbolEqualityComparer.Default.Equals(
+                                propertyType.OriginalDefinition, syntaxListType) &&
+                                IsDerivedFrom(propertyType.TypeArguments[0], nodeType)) {
+                                indentedTextWriter.WriteLine($"foreach (var child in {property.Name})");
                                 indentedTextWriter.WriteLine($"{indentString}yield return child;");
                             }
                         }

--- a/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -216,6 +216,9 @@ public class EvaluatorTests {
 
     [InlineData("int funcA() { int funcB() { return 2; } return funcB() + 1; } return funcA(); ", 3)]
     [InlineData("int funcA() { int funcB() { int funcA() { return 2; } return funcA() + 1; } return funcB() + 1; } return funcA();", 4)]
+
+    [InlineData("struct A { int num; } A myVar = A(); myVar.num = 3; return myVar.num + 1;", 4)]
+    [InlineData("struct A { int num; } struct B { A a; } B myVar = B(); myVar.a = A(); myVar.a.num = 3; return myVar.a.num + 1;", 4)]
     public void Evaluator_Computes_CorrectValues(string text, object expectedValue) {
         AssertValue(text, expectedValue);
     }

--- a/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
+++ b/src/Buckle/Buckle.Tests/CodeAnalysis/EvaluatorTests.cs
@@ -190,9 +190,7 @@ public class EvaluatorTests {
     [InlineData("int x = 4; ref int y = ref x; y++; return x;", 5)]
     [InlineData("int x = 4; int y = 3; ref int z = ref x; z = ref y; z++; return x;", 4)]
 
-    // TODO Add these tests and implement required feature (is/isnt type)
-    // It is commented out right now because this features was bigger than expected,
-    // So this feature is not going to be added in this PR
+    // TODO
     // [InlineData("3 is int;", true)]
     // [InlineData("null is int;", false)]
     // [InlineData("4 is decimal;", false)]
@@ -216,9 +214,8 @@ public class EvaluatorTests {
     [InlineData("(int)3.6;", 3)]
     [InlineData("([NotNull]int)3;", 3)]
 
-    // * Will get fixed with StackFrameParser
-    // [InlineData("int funcA() { int funcB() { return 2; } return funcB() + 1; } return funcA(); ", 3)]
-    // [InlineData("int funcA() { int funcB() { int funcA() { return 2; } return funcA() + 1; } return funcB() + 1; } return funcA();", 3)]
+    [InlineData("int funcA() { int funcB() { return 2; } return funcB() + 1; } return funcA(); ", 3)]
+    [InlineData("int funcA() { int funcB() { int funcA() { return 2; } return funcA() + 1; } return funcB() + 1; } return funcA();", 4)]
     public void Evaluator_Computes_CorrectValues(string text, object expectedValue) {
         AssertValue(text, expectedValue);
     }
@@ -737,14 +734,11 @@ public class EvaluatorTests {
 
     [Fact]
     public void Evaluator_DivideByZero_ThrowsException() {
-        // TODO Need a way to assert exceptions
         var text = @"
             56/0;
         ";
 
-        var diagnostics = @"";
-
-        AssertDiagnostics(text, diagnostics);
+        AssertExceptions(text, new DivideByZeroException());
     }
 
     [Fact]
@@ -801,6 +795,24 @@ public class EvaluatorTests {
         Assert.Equal(expectedValue, result.value);
     }
 
+    private void AssertExceptions(string text, params Exception[] exceptions) {
+        var syntaxTree = SyntaxTree.Parse(text);
+        var compilation = Compilation.CreateScript(null, syntaxTree);
+        var result = compilation.Evaluate(new Dictionary<VariableSymbol, EvaluatorObject>());
+
+        if (exceptions.Length != result.exceptions.Count) {
+            writer.WriteLine($"Input: {text}");
+
+            foreach (var exception in result.exceptions)
+                writer.WriteLine($"Exception ({exception}): {exception.Message}");
+        }
+
+        Assert.Equal(exceptions.Length, result.exceptions.Count);
+
+        for (int i=0; i<exceptions.Length; i++)
+            Assert.Equal(exceptions[i].GetType(), result.exceptions[i].GetType());
+    }
+
     private void AssertDiagnostics(string text, string diagnosticText, bool assertWarnings = false) {
         var annotatedText = AnnotatedText.Parse(text);
         var syntaxTree = SyntaxTree.Parse(annotatedText.text);
@@ -826,6 +838,7 @@ public class EvaluatorTests {
 
         if (expectedDiagnostics.Length != diagnostics.count) {
             writer.WriteLine($"Input: {annotatedText.text}");
+
             foreach (var diagnostic in diagnostics.AsList())
                 writer.WriteLine($"Diagnostic ({diagnostic.info.severity}): {diagnostic.message}");
         }

--- a/src/Buckle/Buckle/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Binding/BoundScope.cs
@@ -76,7 +76,6 @@ internal sealed class BoundScope {
     /// <typeparam name="T">Type of <see cref="Symbol" /> to search for.</typeparam>
     /// <returns><see cref="Symbol" /> if found, null otherwise.</returns>
     internal T LookupSymbol<T>(string name) where T : Symbol {
-        // TODO Add ambiguous error
         if (_symbols != null)
             foreach (var symbol in _symbols)
                 if (symbol.name == name && symbol is T)
@@ -103,7 +102,6 @@ internal sealed class BoundScope {
     /// <returns>If the <see cref="Symbol" /> was found and successfully updated.</returns>
     internal bool TryModifySymbol(string name, Symbol newSymbol) {
         // Does not work with overloads
-        // TODO Need to allow overloads, as someone may try to define overloads for a nested function
         var symbol = LookupSymbol(name);
 
         if (symbol == null)

--- a/src/Buckle/Buckle/CodeAnalysis/Binding/ConstantFolding.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Binding/ConstantFolding.cs
@@ -52,25 +52,8 @@ internal static class ConstantFolding {
         if (leftValue == null || rightValue == null)
             return new BoundConstant(null);
 
-        if (leftType == TypeSymbol.Bool) {
-            leftValue = Convert.ToBoolean(leftValue);
-            rightValue = Convert.ToBoolean(rightValue);
-        } else if (leftType == TypeSymbol.Int) {
-            // Prevents bankers rounding from Convert.ToInt32, instead always truncate (no rounding)
-            if (leftValue.IsFloatingPoint())
-                leftValue = Math.Truncate(Convert.ToDouble(leftValue));
-            if (rightValue.IsFloatingPoint())
-                rightValue = Math.Truncate(Convert.ToDouble(rightValue));
-
-            leftValue = Convert.ToInt32(leftValue);
-            rightValue = Convert.ToInt32(rightValue);
-        } else if (leftType == TypeSymbol.Decimal) {
-            leftValue = Convert.ToDouble(leftValue);
-            rightValue = Convert.ToDouble(rightValue);
-        } else if (leftType == TypeSymbol.String) {
-            leftValue = Convert.ToString(leftValue);
-            rightValue = Convert.ToString(rightValue);
-        }
+        leftValue = CastUtilities.Cast(leftValue, leftType);
+        rightValue = CastUtilities.Cast(rightValue, leftType);
 
         switch (op.opType) {
             case BoundBinaryOperatorType.Addition:

--- a/src/Buckle/Buckle/CodeAnalysis/Emitting/Emitter.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Emitting/Emitter.cs
@@ -17,7 +17,7 @@ namespace Buckle.CodeAnalysis.Emitting;
 /// <summary>
 /// Emits a bound program into a .NET assembly.
 /// </summary>
-internal class Emitter {
+internal sealed class Emitter {
     private readonly List<AssemblyDefinition> _assemblies = new List<AssemblyDefinition>();
     private readonly List<(TypeSymbol type, string metadataName)> _builtinTypes;
     private readonly Dictionary<FunctionSymbol, MethodDefinition> _methods =
@@ -353,10 +353,10 @@ internal class Emitter {
             iLProcessor.Append(end);
 
             var handler = new ExceptionHandler(ExceptionHandlerType.Finally) {
-                TryStart=tryStart,
-                TryEnd=handlerStart,
-                HandlerStart=handlerStart,
-                HandlerEnd=end,
+                TryStart = tryStart,
+                TryEnd = handlerStart,
+                HandlerStart = handlerStart,
+                HandlerEnd = end,
             };
 
             method.Body.ExceptionHandlers.Add(handler);
@@ -385,11 +385,11 @@ internal class Emitter {
             iLProcessor.Append(end);
 
             var handler = new ExceptionHandler(ExceptionHandlerType.Catch) {
-                TryStart=tryStart,
-                TryEnd=handlerStart,
-                HandlerStart=handlerStart,
-                HandlerEnd=end,
-                CatchType=_knownTypes[TypeSymbol.Any],
+                TryStart = tryStart,
+                TryEnd = handlerStart,
+                HandlerStart = handlerStart,
+                HandlerEnd = end,
+                CatchType = _knownTypes[TypeSymbol.Any],
             };
 
             method.Body.ExceptionHandlers.Add(handler);
@@ -422,11 +422,11 @@ internal class Emitter {
             iLProcessor.Append(finallyStart);
 
             var innerHandler = new ExceptionHandler(ExceptionHandlerType.Catch) {
-                TryStart=innerTryStart,
-                TryEnd=innerHandlerStart,
-                HandlerStart=innerHandlerStart,
-                HandlerEnd=finallyStart,
-                CatchType=_knownTypes[TypeSymbol.Any],
+                TryStart = innerTryStart,
+                TryEnd = innerHandlerStart,
+                HandlerStart = innerHandlerStart,
+                HandlerEnd = finallyStart,
+                CatchType = _knownTypes[TypeSymbol.Any],
             };
 
             foreach (var node in finallyBody)
@@ -436,10 +436,10 @@ internal class Emitter {
             iLProcessor.Append(end);
 
             var handler = new ExceptionHandler(ExceptionHandlerType.Finally) {
-                TryStart=innerTryStart,
-                TryEnd=finallyStart,
-                HandlerStart=finallyStart,
-                HandlerEnd=end,
+                TryStart = innerTryStart,
+                TryEnd = finallyStart,
+                HandlerStart = finallyStart,
+                HandlerEnd = end,
             };
 
             method.Body.ExceptionHandlers.Add(innerHandler);

--- a/src/Buckle/Buckle/CodeAnalysis/Emitting/EmitterOld.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Emitting/EmitterOld.cs
@@ -17,7 +17,7 @@ using Diagnostics;
 
 namespace Buckle.CodeAnalysis.Emitting;
 
-internal class _Emitter {
+internal sealed class _Emitter {
     internal BelteDiagnosticQueue diagnostics = new BelteDiagnosticQueue();
 
     private readonly List<AssemblyDefinition> _assemblies = new List<AssemblyDefinition>();
@@ -330,10 +330,10 @@ internal class _Emitter {
             iLProcessor.Append(end);
 
             var handler = new ExceptionHandler(ExceptionHandlerType.Finally) {
-                TryStart=tryStart,
-                TryEnd=handlerStart,
-                HandlerStart=handlerStart,
-                HandlerEnd=end,
+                TryStart = tryStart,
+                TryEnd = handlerStart,
+                HandlerStart = handlerStart,
+                HandlerEnd = end,
             };
 
             method.Body.ExceptionHandlers.Add(handler);
@@ -362,11 +362,11 @@ internal class _Emitter {
             iLProcessor.Append(end);
 
             var handler = new ExceptionHandler(ExceptionHandlerType.Catch) {
-                TryStart=tryStart,
-                TryEnd=handlerStart,
-                HandlerStart=handlerStart,
-                HandlerEnd=end,
-                CatchType=_knownTypes[TypeSymbol.Any],
+                TryStart = tryStart,
+                TryEnd = handlerStart,
+                HandlerStart = handlerStart,
+                HandlerEnd = end,
+                CatchType = _knownTypes[TypeSymbol.Any],
             };
 
             method.Body.ExceptionHandlers.Add(handler);
@@ -399,11 +399,11 @@ internal class _Emitter {
             iLProcessor.Append(finallyStart);
 
             var innerHandler = new ExceptionHandler(ExceptionHandlerType.Catch) {
-                TryStart=innerTryStart,
-                TryEnd=innerHandlerStart,
-                HandlerStart=innerHandlerStart,
-                HandlerEnd=finallyStart,
-                CatchType=_knownTypes[TypeSymbol.Any],
+                TryStart = innerTryStart,
+                TryEnd = innerHandlerStart,
+                HandlerStart = innerHandlerStart,
+                HandlerEnd = finallyStart,
+                CatchType = _knownTypes[TypeSymbol.Any],
             };
 
             foreach (var node in finallyBody)
@@ -413,10 +413,10 @@ internal class _Emitter {
             iLProcessor.Append(end);
 
             var handler = new ExceptionHandler(ExceptionHandlerType.Finally) {
-                TryStart=innerTryStart,
-                TryEnd=finallyStart,
-                HandlerStart=finallyStart,
-                HandlerEnd=end,
+                TryStart = innerTryStart,
+                TryEnd = finallyStart,
+                HandlerStart = finallyStart,
+                HandlerEnd = end,
             };
 
             method.Body.ExceptionHandlers.Add(innerHandler);

--- a/src/Buckle/Buckle/CodeAnalysis/Evaluating/EvaluationResult.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Evaluating/EvaluationResult.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Buckle.Diagnostics;
 
 namespace Buckle.CodeAnalysis.Evaluating;
@@ -11,17 +13,19 @@ internal sealed class EvaluationResult {
     /// </summary>
     /// <param name="value">Result of evaluation.</param>
     /// <param name="diagnostics">Diagnostics associated with value.</param>
-    internal EvaluationResult(object value, bool hasValue, BelteDiagnosticQueue diagnostics) {
+    internal EvaluationResult(
+        object value, bool hasValue, BelteDiagnosticQueue diagnostics, List<Exception> exceptions) {
         this.value = value;
         this.hasValue = hasValue;
         this.diagnostics = new BelteDiagnosticQueue();
         this.diagnostics.Move(diagnostics);
+        this.exceptions = exceptions == null ? new List<Exception>() : new List<Exception>(exceptions);
     }
 
     /// <summary>
     /// Creates an empty <see cref="EvaluationResult" />.
     /// </summary>
-    internal EvaluationResult() : this(null, false, null) { }
+    internal EvaluationResult() : this(null, false, null, null) { }
 
     /// <summary>
     /// Diagnostics related to a single evaluation.
@@ -37,4 +41,9 @@ internal sealed class EvaluationResult {
     /// Flag to distinguish the lack of value from the value of null.
     /// </summary>
     internal bool hasValue { get; set; }
+
+    /// <summary>
+    /// All exceptions thrown while evaluating.
+    /// </summary>
+    internal List<Exception> exceptions { get; set; }
 }

--- a/src/Buckle/Buckle/CodeAnalysis/Evaluating/Evaluator.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Evaluating/Evaluator.cs
@@ -10,21 +10,17 @@ using static Buckle.Utilities.FunctionUtilities;
 namespace Buckle.CodeAnalysis.Evaluating;
 
 /// <summary>
-/// Evaluates BoundStatements as an interpreter, inline.
+/// Evaluates BoundStatements inline similar to an interpreter.
 /// </summary>
 internal sealed class Evaluator {
     private readonly BoundProgram _program;
-    private readonly Dictionary<VariableSymbol, EvaluatorObject> _globals;
     private readonly Dictionary<FunctionSymbol, BoundBlockStatement> _functions =
         new Dictionary<FunctionSymbol, BoundBlockStatement>();
-    private readonly Stack<Dictionary<VariableSymbol, EvaluatorObject>> _locals =
-        new Stack<Dictionary<VariableSymbol, EvaluatorObject>>();
     private readonly Dictionary<TypeSymbol, ImmutableList<FieldSymbol>> _types =
         new Dictionary<TypeSymbol, ImmutableList<FieldSymbol>>();
-    private EvaluatorObject _lastValue;
-    private Random _random;
-    private bool _hasPrint = false;
-    private bool _hasValue = true;
+    private readonly Dictionary<VariableSymbol, EvaluatorObject> _globals;
+    private readonly Stack<Dictionary<VariableSymbol, EvaluatorObject>> _locals =
+        new Stack<Dictionary<VariableSymbol, EvaluatorObject>>();
 
     /// <summary>
     /// Creates an <see cref="Evaluator" /> that can evaluate a <see cref="BoundProgram" /> (provided globals).
@@ -33,6 +29,7 @@ internal sealed class Evaluator {
     /// <param name="globals">Globals.</param>
     internal Evaluator(BoundProgram program, Dictionary<VariableSymbol, EvaluatorObject> globals) {
         diagnostics = new BelteDiagnosticQueue();
+        exceptions = new List<Exception>();
         _program = program;
         _globals = globals;
         _locals.Push(new Dictionary<VariableSymbol, EvaluatorObject>());
@@ -64,9 +61,19 @@ internal sealed class Evaluator {
     }
 
     /// <summary>
+    /// All thrown exceptions during evaluation.
+    /// </summary>
+    internal List<Exception> exceptions { get; set; }
+
+    /// <summary>
     /// Diagnostics specific to the <see cref="Evaluator" />.
     /// </summary>
     internal BelteDiagnosticQueue diagnostics { get; set; }
+
+    private EvaluatorObject _lastValue;
+    private Random _random;
+    private bool _hasPrint = false;
+    private bool _hasValue = false;
 
     /// <summary>
     /// Evaluate the provided <see cref="BoundProgram" />.
@@ -86,30 +93,32 @@ internal sealed class Evaluator {
         return Value(result, true);
     }
 
-    private object GetVariableValue(
-        VariableSymbol variable, FieldSymbol member=null, bool traceCollections=false) {
+    private object GetVariableValue(VariableSymbol variable, bool traceCollections = false) {
         EvaluatorObject value = null;
 
         if (variable.type == SymbolType.GlobalVariable) {
-            value = _globals[variable];
+            value = GetFrom(_globals, variable);
         } else {
             var locals = _locals.Peek();
-            value = locals[variable];
-        }
-
-        if (member != null) {
-            var dictionary = Value(value) as Dictionary<FieldSymbol, EvaluatorObject>;
-            value = dictionary[member];
+            value = GetFrom(locals, variable);
         }
 
         return Value(value, traceCollections);
+    }
+
+    private EvaluatorObject GetFrom(Dictionary<VariableSymbol, EvaluatorObject> variables, VariableSymbol variable) {
+        foreach (var pair in variables)
+            if (variable.name == pair.Key.name && BoundTypeClause.Equals(variable.typeClause, pair.Key.typeClause))
+                return pair.Value;
+
+        throw new BelteInternalException($"GetFrom: '{variable.name}' was not found in the scope");
     }
 
     private object DictionaryValue(Dictionary<FieldSymbol, EvaluatorObject> value) {
         var dictionary = new Dictionary<object, object>();
 
         foreach (var pair in value)
-            dictionary.Add(pair.Key.name, Value(pair.Value));
+            dictionary.Add(pair.Key.name, Value(pair.Value, true));
 
         return dictionary;
     }
@@ -123,9 +132,9 @@ internal sealed class Evaluator {
         return builder.ToArray();
     }
 
-    private object Value(EvaluatorObject value, bool traceCollections=false) {
+    private object Value(EvaluatorObject value, bool traceCollections = false) {
         if (value.isReference)
-            return GetVariableValue(value.reference, value.fieldReference, traceCollections);
+            return GetVariableValue(value.reference, traceCollections);
         else if (value.value is EvaluatorObject)
             return Value(value.value as EvaluatorObject, traceCollections);
         else if (value.value is EvaluatorObject[] && traceCollections)
@@ -136,7 +145,82 @@ internal sealed class Evaluator {
             return value.value;
     }
 
+    private void Create(VariableSymbol left, EvaluatorObject right) {
+        if (left.type == SymbolType.GlobalVariable) {
+            var set = false;
+
+            foreach (var global in _globals) {
+                if (global.Key.name == left.name) {
+                    _globals.Remove(global.Key);
+                    _globals[left] = right;
+                    set = true;
+                    break;
+                }
+            }
+
+            if (!set)
+                _globals[left] = right;
+        } else {
+            var locals = _locals.Peek();
+            var set = false;
+
+            foreach (var local in locals) {
+                if (local.Key.name == left.name) {
+                    locals.Remove(local.Key);
+                    locals[left] = right;
+                    set = true;
+                    break;
+                }
+            }
+
+            if (!set)
+                locals[left] = right;
+        }
+    }
+
+    private void Assign(EvaluatorObject left, EvaluatorObject right) {
+        while (right.isReference && !right.isExplicitReference) {
+            if (right.nestedReference != null) {
+                right = right.nestedReference.members[right.reference as FieldSymbol];
+            } else if (right.reference.type == SymbolType.GlobalVariable) {
+                right = GetFrom(_globals, right.reference);
+            } else {
+                var locals = _locals.Peek();
+                right = GetFrom(locals, right.reference);
+            }
+        }
+
+        while (left.isReference && !left.isExplicitReference) {
+            if (left.nestedReference != null) {
+                left = left.nestedReference.members[left.reference as FieldSymbol];
+            } else if (left.reference.type == SymbolType.GlobalVariable) {
+                left = GetFrom(_globals, left.reference);
+            } else {
+                var locals = _locals.Peek();
+                left = GetFrom(locals, left.reference);
+            }
+        }
+
+        if (right.isExplicitReference) {
+            left.reference = right.reference;
+        } else if (left.isExplicitReference) {
+            while (left.isReference) {
+                if (left.reference.type == SymbolType.GlobalVariable) {
+                    left = GetFrom(_globals, left.reference);
+                } else {
+                    var locals = _locals.Peek();
+                    left = GetFrom(locals, left.reference);
+                }
+            }
+            left.value = Value(right);
+        } else {
+            left.value = Value(right);
+        }
+    }
+
     private EvaluatorObject EvaluateStatement(BoundBlockStatement statement) {
+        _hasValue = false;
+
         try {
             var labelToIndex = new Dictionary<BoundLabel, int>();
 
@@ -154,6 +238,7 @@ internal sealed class Evaluator {
                         index++;
                         break;
                     case BoundNodeType.ExpressionStatement:
+                        _hasValue = true;
                         EvaluateExpressionStatement((BoundExpressionStatement)s);
                         index++;
                         break;
@@ -181,9 +266,10 @@ internal sealed class Evaluator {
                     case BoundNodeType.ReturnStatement:
                         var returnStatement = (BoundReturnStatement)s;
                         var _lastValue = returnStatement.expression == null
-                            ? null
+                            ? new EvaluatorObject()
                             : EvaluateExpression(returnStatement.expression);
 
+                        _hasValue = returnStatement.expression == null ? false : true;
                         return _lastValue;
                     default:
                         throw new BelteInternalException($"EvaluateStatement: unexpected statement '{s.type}'");
@@ -192,61 +278,25 @@ internal sealed class Evaluator {
 
             return _lastValue;
         } catch (Exception e) when (!(e is BelteInternalException)) {
+            exceptions.Add(e);
             var previous = Console.ForegroundColor;
             Console.ForegroundColor = ConsoleColor.Red;
             Console.Write("Unhandled exception: ");
             Console.ForegroundColor = previous;
             Console.WriteLine(e.Message);
-            return new EvaluatorObject(null);
+            _hasValue = false;
+            return new EvaluatorObject();
         }
     }
 
     private void EvaluateExpressionStatement(BoundExpressionStatement statement) {
-        _hasValue = true;
         _lastValue = EvaluateExpression(statement.expression);
     }
 
     private void EvaluateVariableDeclarationStatement(BoundVariableDeclarationStatement statement) {
         var value = EvaluateExpression(statement.initializer);
         _lastValue = null;
-        _hasValue = false;
-        Assign(statement.variable, value);
-    }
-
-    private void Assign(VariableSymbol variable, EvaluatorObject value, FieldSymbol field=null) {
-        if (value.isReference && !value.isExplicitReference) {
-            if (value.reference.type == SymbolType.GlobalVariable) {
-                value = _globals[value.reference];
-            } else {
-                var locals = _locals.Peek();
-                value = locals[value.reference];
-            }
-        }
-
-        if (variable.type == SymbolType.GlobalVariable) {
-            var currentValue = _globals.ContainsKey(variable) ? _globals[variable] : null;
-
-            if (currentValue != null && currentValue.isReference && !value.isReference) {
-                Assign(currentValue.reference, value, field);
-            } else {
-                if (field == null)
-                    _globals[variable] = value;
-                else
-                    ((Dictionary<FieldSymbol, EvaluatorObject>)(_globals[variable].value))[field] = value;
-            }
-        } else {
-            var locals = _locals.Peek();
-            var currentValue = locals.ContainsKey(variable) ? locals[variable] : null;
-
-            if (currentValue != null && currentValue.isReference && !value.isReference) {
-                Assign(currentValue.reference, value, field);
-            } else {
-                if (field == null)
-                    locals[variable] = value;
-                else
-                    ((Dictionary<FieldSymbol, EvaluatorObject>)(locals[variable].value))[field] = value;
-            }
-        }
+        Create(statement.variable, value);
     }
 
     private EvaluatorObject EvaluateExpression(BoundExpression node) {
@@ -280,7 +330,7 @@ internal sealed class Evaluator {
             case BoundNodeType.TypeOfExpression:
                 return EvaluateTypeOfExpression((BoundTypeOfExpression)node);
             case BoundNodeType.EmptyExpression:
-                return new EvaluatorObject(null);
+                return new EvaluatorObject();
             case BoundNodeType.ConstructorExpression:
                 return EvaluateConstructorExpression((BoundConstructorExpression)node);
             case BoundNodeType.MemberAccessExpression:
@@ -291,40 +341,31 @@ internal sealed class Evaluator {
     }
 
     private EvaluatorObject EvaluateMemberAccessExpression(BoundMemberAccessExpression node) {
-        if (node.operand is BoundVariableExpression v) {
-            // By reference
-            return new EvaluatorObject(v.variable, node.member);
-        }
-
         var operand = EvaluateExpression(node.operand);
 
-        if (operand.isReference) {
-            // By reference
-            return new EvaluatorObject(operand.reference, node.member);
-        } else {
-            // By value
-            var value = Value(operand) as Dictionary<FieldSymbol, EvaluatorObject>;
-            return new EvaluatorObject(value[node.member]);
-        }
+        if (operand.isReference)
+            return new EvaluatorObject(node.member, operand);
+        else
+            return new EvaluatorObject(operand.members[node.member]);
     }
 
     private EvaluatorObject EvaluateConstructorExpression(BoundConstructorExpression node) {
         var body = _types[node.symbol];
-        var value = new Dictionary<FieldSymbol, EvaluatorObject>();
+        var members = new Dictionary<FieldSymbol, EvaluatorObject>();
 
         foreach (var field in body)
-            value.Add(field, new EvaluatorObject(null));
+            members.Add(field, new EvaluatorObject());
 
-        return new EvaluatorObject(value);
+        return new EvaluatorObject(members);
     }
 
     private EvaluatorObject EvaluateTypeOfExpression(BoundTypeOfExpression node) {
         // TODO Implement typeof and type types
-        return new EvaluatorObject(null);
+        return new EvaluatorObject();
     }
 
     private EvaluatorObject EvaluateReferenceExpression(BoundReferenceExpression node) {
-        return new EvaluatorObject(node.variable, true);
+        return new EvaluatorObject(node.variable, isExplicitReference: true);
     }
 
     private EvaluatorObject EvaluateIndexExpression(BoundIndexExpression node) {
@@ -352,29 +393,14 @@ internal sealed class Evaluator {
     }
 
     private EvaluatorObject EvaluateCast(EvaluatorObject value, BoundTypeClause typeClause) {
-        if (Value(value) == null)
-            return new EvaluatorObject(null);
+        var valueValue = Value(value);
+
+        if (valueValue == null)
+            return new EvaluatorObject();
 
         var type = typeClause.lType;
-
-        if (type == TypeSymbol.Any) {
-            return value;
-        } else if (type == TypeSymbol.Bool) {
-            return new EvaluatorObject(Convert.ToBoolean(Value(value)));
-        } else if (type == TypeSymbol.Int) {
-            if (Value(value).IsFloatingPoint())
-                value = new EvaluatorObject(Math.Truncate(Convert.ToDouble(Value(value))));
-
-            return new EvaluatorObject(Convert.ToInt32(Value(value)));
-        } else if (type == TypeSymbol.String) {
-            return new EvaluatorObject(Convert.ToString(Value(value)));
-        } else if (type == TypeSymbol.Decimal) {
-            return new EvaluatorObject(Convert.ToDouble(Value(value)));
-        } else if (type is StructSymbol) {
-            return value;
-        }
-
-        throw new BelteInternalException($"EvaluateCast: unexpected type '{typeClause}'");
+        valueValue = CastUtilities.Cast(valueValue, type);
+        return new EvaluatorObject(valueValue);
     }
 
     private EvaluatorObject EvaluateCallExpression(BoundCallExpression node) {
@@ -425,8 +451,7 @@ internal sealed class Evaluator {
             return result;
         }
 
-        _hasValue = false;
-        return new EvaluatorObject(null);
+        return new EvaluatorObject();
     }
 
     private EvaluatorObject EvaluateConstantExpression(BoundExpression expression) {
@@ -440,32 +465,35 @@ internal sealed class Evaluator {
     private EvaluatorObject EvaluateAssignmentExpresion(BoundAssignmentExpression expression) {
         var left = EvaluateExpression(expression.left);
         var right = EvaluateExpression(expression.right);
-        Assign(left.reference, right, left.fieldReference);
+        Assign(left, right);
 
         return right;
     }
 
     private EvaluatorObject EvaluateUnaryExpression(BoundUnaryExpression expression) {
         var operand = EvaluateExpression(expression.operand);
+        var operandValue = Value(operand);
 
-        if (Value(operand) == null)
-            return new EvaluatorObject(null);
+        if (operandValue == null)
+            return new EvaluatorObject();
+
+        operandValue = CastUtilities.Cast(operandValue, expression.op.operandType.lType);
 
         switch (expression.op.opType) {
             case BoundUnaryOperatorType.NumericalIdentity:
                 if (expression.operand.typeClause.lType == TypeSymbol.Int)
-                    return new EvaluatorObject((int)Value(operand));
+                    return new EvaluatorObject((int)operandValue);
                 else
-                    return new EvaluatorObject((double)Value(operand));
+                    return new EvaluatorObject((double)operandValue);
             case BoundUnaryOperatorType.NumericalNegation:
                 if (expression.operand.typeClause.lType == TypeSymbol.Int)
-                    return new EvaluatorObject(-(int)Value(operand));
+                    return new EvaluatorObject(-(int)operandValue);
                 else
-                    return new EvaluatorObject(-(double)Value(operand));
+                    return new EvaluatorObject(-(double)operandValue);
             case BoundUnaryOperatorType.BooleanNegation:
-                return new EvaluatorObject(!(bool)Value(operand));
+                return new EvaluatorObject(!(bool)operandValue);
             case BoundUnaryOperatorType.BitwiseCompliment:
-                return new EvaluatorObject(~(int)Value(operand));
+                return new EvaluatorObject(~(int)operandValue);
             default:
                 throw new BelteInternalException($"EvaluateUnaryExpression: unknown unary operator '{expression.op}'");
         }
@@ -474,6 +502,7 @@ internal sealed class Evaluator {
     private EvaluatorObject EvaluateTernaryExpression(BoundTernaryExpression expression) {
         var left = EvaluateExpression(expression.left);
         var leftValue = Value(left);
+        leftValue = CastUtilities.Cast(leftValue, expression.op.leftType.lType);
 
         switch (expression.op.opType) {
             case BoundTernaryOperatorType.Conditional:
@@ -523,10 +552,14 @@ internal sealed class Evaluator {
         var rightValue = Value(right);
 
         if (leftValue == null || rightValue == null)
-            return new EvaluatorObject(null);
+            return new EvaluatorObject();
 
         var expressionType = expression.typeClause.lType;
         var leftType = expression.left.typeClause.lType;
+        var rightType = expression.right.typeClause.lType;
+
+        leftValue = CastUtilities.Cast(leftValue, expression.op.leftType.lType);
+        rightValue = CastUtilities.Cast(rightValue, expression.op.rightType.lType);
 
         switch (expression.op.opType) {
             case BoundBinaryOperatorType.Addition:

--- a/src/Buckle/Buckle/CodeAnalysis/Evaluating/EvaluatorObject.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Evaluating/EvaluatorObject.cs
@@ -55,12 +55,11 @@ internal sealed class EvaluatorObject {
     /// </param>
     /// <param name="isExplicitReference">If this is just a variable, or if it explicitly a reference expression.</param>
     internal EvaluatorObject(
-        VariableSymbol reference, EvaluatorObject nestedReference = null, bool isExplicitReference = false) {
+        VariableSymbol reference, bool isExplicitReference = false) {
         this.value = null;
         this.isReference = true;
         this.reference = reference;
         this.isExplicitReference = isExplicitReference;
-        this.nestedReference = nestedReference;
         this.members = null;
     }
 
@@ -86,11 +85,6 @@ internal sealed class EvaluatorObject {
     /// Not explicitly a reference, but is passed by reference by default.
     /// </summary>
     internal VariableSymbol reference { get; set; }
-
-    /// <summary>
-    /// The owner of this.
-    /// </summary>
-    internal EvaluatorObject nestedReference { get; set; }
 
     /// <summary>
     /// Members stored by this.

--- a/src/Buckle/Buckle/CodeAnalysis/Evaluating/EvaluatorObject.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Evaluating/EvaluatorObject.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Buckle.CodeAnalysis.Symbols;
 
 namespace Buckle.CodeAnalysis.Evaluating;
@@ -7,6 +8,17 @@ namespace Buckle.CodeAnalysis.Evaluating;
 /// </summary>
 internal sealed class EvaluatorObject {
     /// <summary>
+    /// Creates an <see cref="EvaluatorObject" /> with a null value.
+    /// </summary>
+    internal EvaluatorObject() {
+        this.value = null;
+        this.isReference = false;
+        this.reference = null;
+        this.isExplicitReference = false;
+        this.members = null;
+    }
+
+    /// <summary>
     /// Creates an <see cref="EvaluatorObject" /> with a value (not a reference).
     /// In this case <see cref="EvaluatorObject" /> acts purely as an Object wrapper.
     /// </summary>
@@ -15,31 +27,20 @@ internal sealed class EvaluatorObject {
         this.value = value;
         this.isReference = false;
         this.reference = null;
+        this.isExplicitReference = false;
+        this.members = null;
     }
 
     /// <summary>
-    /// Creates an <see cref="EvaluatorObjet" /> without a value, and instead a reference to
-    /// a <see cref="VariableSymbol" />.
-    /// Note that it is not an actual C# reference, just a copy of a <see cref="VariableSymbol" /> stored in the locals
-    /// or globals dictionary.
+    /// Creates an <see cref="EvaluatorObject" /> without a value, and instead a list of members.
     /// </summary>
-    /// <param name="reference">
-    /// <see cref="VariableSymbol" /> to reference (not an explicit reference, passed by
-    /// reference by default).
-    /// </param>
-    internal EvaluatorObject(VariableSymbol reference, bool explicitReference=false) {
+    /// <param name="members">Members to contain by this.</param>
+    internal EvaluatorObject(Dictionary<FieldSymbol, EvaluatorObject> members) {
         this.value = null;
-
-        if (reference == null) {
-            this.isReference = false;
-            this.reference = null;
-        } else {
-            this.isReference = true;
-            this.reference = reference;
-        }
-
-        this.fieldReference = null;
-        this.isExplicitReference = explicitReference;
+        this.isReference = false;
+        this.reference = null;
+        this.isExplicitReference = false;
+        this.members = members;
     }
 
     /// <summary>
@@ -52,12 +53,15 @@ internal sealed class EvaluatorObject {
     /// <see cref="VariableSymbol" /> to reference (not an explicit reference, passed by
     /// reference by default).
     /// </param>
-    /// <param name="fieldReference"><see cref="FieldSymbol" /> to reference.</param>
-    internal EvaluatorObject(VariableSymbol reference, FieldSymbol fieldReference) {
+    /// <param name="isExplicitReference">If this is just a variable, or if it explicitly a reference expression.</param>
+    internal EvaluatorObject(
+        VariableSymbol reference, EvaluatorObject nestedReference = null, bool isExplicitReference = false) {
         this.value = null;
         this.isReference = true;
         this.reference = reference;
-        this.fieldReference = fieldReference;
+        this.isExplicitReference = isExplicitReference;
+        this.nestedReference = nestedReference;
+        this.members = null;
     }
 
     /// <summary>
@@ -84,7 +88,12 @@ internal sealed class EvaluatorObject {
     internal VariableSymbol reference { get; set; }
 
     /// <summary>
-    /// Reference to a <see cref="FieldSymbol" /> member of <see cref="EvaluatorObject.reference" />.
+    /// The owner of this.
     /// </summary>
-    internal FieldSymbol fieldReference { get; set; }
+    internal EvaluatorObject nestedReference { get; set; }
+
+    /// <summary>
+    /// Members stored by this.
+    /// </summary>
+    internal Dictionary<FieldSymbol, EvaluatorObject> members { get; set; }
 }

--- a/src/Buckle/Buckle/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Lowering/Lowerer.cs
@@ -276,6 +276,7 @@ internal sealed class Lowerer : BoundTreeRewriter {
 
         if (expression.op.opType == BoundBinaryOperatorType.Power) {
             // TODO
+            // * Will do in the StackFrameParser
             return base.RewriteBinaryExpression(expression);
         }
 

--- a/src/Buckle/Buckle/CodeAnalysis/Parser/Lexer.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Parser/Lexer.cs
@@ -92,7 +92,6 @@ internal sealed class Lexer {
                     break;
                 case '/':
                     if (lookahead == '/')
-                        // TODO Docstring comments (xml/doxygen, probably xml)
                         ReadSingeLineComment();
                     else if (lookahead == '*')
                         ReadMultiLineComment();

--- a/src/Buckle/Buckle/CodeAnalysis/Parser/Parser.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Parser/Parser.cs
@@ -234,7 +234,7 @@ internal sealed class Parser {
         var closeParenthesis = Match(SyntaxType.CloseParenToken);
         var body = (BlockStatement)ParseBlockStatement();
 
-        return new FunctionDeclaration(
+        return new MethodDeclaration(
             _syntaxTree, typeClause, identifier, openParenthesis, parameters, closeParenthesis, body);
     }
 
@@ -398,7 +398,7 @@ internal sealed class Parser {
             _syntaxTree, doKeyword, body, whileKeyword, openParenthesis, condition, closeParenthesis, semicolon);
     }
 
-    private Statement ParseVariableDeclarationStatement(bool allowDefinition=true) {
+    private Statement ParseVariableDeclarationStatement(bool allowDefinition = true) {
         var typeClause = ParseTypeClause();
         var identifier = Match(SyntaxType.IdentifierToken);
 
@@ -414,7 +414,7 @@ internal sealed class Parser {
             }
         }
 
-        var semicolon = Match(SyntaxType.SemicolonToken, suppressErrors: true);
+        var semicolon = Match(SyntaxType.SemicolonToken);
 
         return new VariableDeclarationStatement(
             _syntaxTree, typeClause, identifier, equals, initializer, semicolon);
@@ -821,7 +821,7 @@ internal sealed class Parser {
     }
 
     private Expression ParsePrimaryOperatorExpression(
-        Node operand, int parentPrecedence = 0, Token maybeUnexpected=null) {
+        Node operand, int parentPrecedence = 0, Token maybeUnexpected = null) {
         Node ParseCorrectPrimaryOperator(Node operand) {
             if (operand.type == SyntaxType.TypeOfKeyword)
                 return ParseTypeOfExpression();
@@ -876,7 +876,7 @@ internal sealed class Parser {
         if (current.type == SyntaxType.TypeOfKeyword)
             left = current;
         else
-            left = ParseNameExpression(true);
+            left = ParseNameExpression();
 
         return ParsePrimaryOperatorExpression(left, maybeUnexpected: maybeUnexpected);
     }
@@ -932,8 +932,8 @@ internal sealed class Parser {
         return new SeparatedSyntaxList<Expression>(nodesAndSeparators.ToImmutable());
     }
 
-    private Expression ParseNameExpression(bool suppressErrors = false) {
-        var identifier = Match(SyntaxType.IdentifierToken, suppressErrors: suppressErrors);
+    private Expression ParseNameExpression() {
+        var identifier = Match(SyntaxType.IdentifierToken, suppressErrors: true);
         return new NameExpression(_syntaxTree, identifier);
     }
 }

--- a/src/Buckle/Buckle/CodeAnalysis/Preprocessing/Preprocessor.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Preprocessing/Preprocessor.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Buckle.CodeAnalysis.Text;
+using Buckle.Diagnostics;
 
 // * Needs to use the lexer, parser, and constant evaluator to evaluate statements like #run, #if, #elif, and #define
 
@@ -8,8 +9,12 @@ namespace Buckle.CodeAnalysis.Preprocessing;
 /// <summary>
 /// Evaluates preprocessor statements
 /// </summary>
-internal class Preprocessor {
+internal sealed class Preprocessor {
     private Dictionary<string, string> symbols = new Dictionary<string, string>();
+
+    internal Preprocessor() {
+        diagnostics = new BelteDiagnosticQueue();
+    }
 
     /// <summary>
     /// Preprocesses a file.
@@ -30,4 +35,6 @@ internal class Preprocessor {
         // ! Temp code - just so it compiles
         return text;
     }
+
+    internal BelteDiagnosticQueue diagnostics;
 }

--- a/src/Buckle/Buckle/CodeAnalysis/Symbols/FieldSymbol.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Symbols/FieldSymbol.cs
@@ -3,7 +3,7 @@ using Buckle.CodeAnalysis.Binding;
 namespace Buckle.CodeAnalysis.Symbols;
 
 /// <summary>
-/// A local variable symbol. This is a variable declared anywhere except the global scope (thus being more local).
+/// A field symbol. This is a variable declared as a member of a type.
 /// </summary>
 internal class FieldSymbol : VariableSymbol {
     /// <summary>

--- a/src/Buckle/Buckle/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -17,7 +17,7 @@ internal sealed class FunctionSymbol : Symbol {
     /// <param name="declaration">Declaration of function.</param>
     internal FunctionSymbol(
         string name, ImmutableArray<ParameterSymbol> parameters,
-        BoundTypeClause typeClause, FunctionDeclaration declaration = null)
+        BoundTypeClause typeClause, MethodDeclaration declaration = null)
         : base(name) {
         this.typeClause = typeClause;
         this.parameters = parameters;
@@ -35,9 +35,9 @@ internal sealed class FunctionSymbol : Symbol {
     internal BoundTypeClause typeClause { get; }
 
     /// <summary>
-    /// Declaration of function (see <see cref="FunctionDeclaration">).
+    /// Declaration of function (see <see cref="MethodDeclaration">).
     /// </summary>
-    internal FunctionDeclaration declaration { get; }
+    internal MethodDeclaration declaration { get; }
 
     internal override SymbolType type => SymbolType.Function;
 

--- a/src/Buckle/Buckle/CodeAnalysis/Symbols/VariableSymbol.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Symbols/VariableSymbol.cs
@@ -12,8 +12,7 @@ internal abstract class VariableSymbol : Symbol {
     /// <param name="name">Name of the variable.</param>
     /// <param name="typeClause"><see cref="BoundTypeClause" /> of the variable.</param>
     /// <param name="constant"><see cref="ConstantValue" /> of the variable.</param>
-    internal VariableSymbol(string name, BoundTypeClause typeClause, BoundConstant constant)
-        : base(name) {
+    internal VariableSymbol(string name, BoundTypeClause typeClause, BoundConstant constant) : base(name) {
         this.typeClause = typeClause;
         constantValue = typeClause.isConstant && !typeClause.isReference ? constant : null;
     }

--- a/src/Buckle/Buckle/CodeAnalysis/Syntax/InlineFunctionExpression.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Syntax/InlineFunctionExpression.cs
@@ -2,7 +2,6 @@ using System.Collections.Immutable;
 
 namespace Buckle.CodeAnalysis.Syntax;
 
-// TODO Make sure that block statements can still have return statements (they might)
 /// <summary>
 /// Inline function expression, similar to local function but is evaluated immediately and has no signature.<br/>
 /// E.g.

--- a/src/Buckle/Buckle/CodeAnalysis/Syntax/InternalSyntax/Node.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Syntax/InternalSyntax/Node.cs
@@ -109,41 +109,49 @@ internal abstract class Node {
         var token = node as Token;
 
         if (isConsoleOut)
-            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.ForegroundColor = ConsoleColor.Red;
 
         if (token != null) {
             foreach (var trivia in token.leadingTrivia) {
                 writer.Write(indent);
                 writer.Write("├─");
-                writer.WriteLine($"L: {trivia.type}");
+                writer.WriteLine($"Lead: {trivia.type} [{trivia.span.start}..{trivia.span.end})");
             }
         }
 
         var hasTrailingTrivia = token != null && token.trailingTrivia.Any();
         var tokenMarker = !hasTrailingTrivia && isLast ? "└─" : "├─";
+
+        if (isConsoleOut)
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+
         writer.Write($"{indent}{tokenMarker}");
 
         if (isConsoleOut)
-            Console.ForegroundColor = node is Token ? ConsoleColor.DarkBlue : ConsoleColor.Cyan;
+            Console.ForegroundColor = node is Token ? ConsoleColor.Green : ConsoleColor.Blue;
 
         writer.Write(node.type);
 
         if (node is Token t && t.value != null)
             writer.Write($" {t.value}");
 
-        writer.WriteLine();
-
-        if (isConsoleOut)
-            Console.ForegroundColor = ConsoleColor.DarkGray;
+        writer.WriteLine($" [{node.span.start}..{node.span.end})");
 
         if (token != null) {
             foreach (var trivia in token.trailingTrivia) {
                 var isLastTrailingTrivia = trivia == token.trailingTrivia.Last();
                 var triviaMarker = isLast && isLastTrailingTrivia ? "└─" : "├─";
 
+                if (isConsoleOut)
+                    Console.ForegroundColor = ConsoleColor.DarkGray;
+
                 writer.Write(indent);
                 writer.Write(triviaMarker);
-                writer.WriteLine($"T: {trivia.type}");
+
+                if (isConsoleOut)
+                    Console.ForegroundColor = ConsoleColor.Red;
+
+                writer.WriteLine($"Trail: {trivia.type} [{trivia.span.start}..{trivia.span.end})");
             }
         }
 

--- a/src/Buckle/Buckle/CodeAnalysis/Syntax/InternalSyntax/SyntaxType.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Syntax/InternalSyntax/SyntaxType.cs
@@ -1,7 +1,6 @@
 
 namespace Buckle.CodeAnalysis.Syntax;
 
-// TODO : uint?
 /// <summary>
 /// All types of things to be found in a source file.
 /// </summary>

--- a/src/Buckle/Buckle/CodeAnalysis/Syntax/Members/MethodDeclaration.cs
+++ b/src/Buckle/Buckle/CodeAnalysis/Syntax/Members/MethodDeclaration.cs
@@ -2,18 +2,18 @@
 namespace Buckle.CodeAnalysis.Syntax;
 
 /// <summary>
-/// Function declaration (including body).
+/// Method declaration (including body).
 /// E.g.
 /// <code>
-/// void FunctionName(int a) {
+/// void MethodName(int a) {
 ///     Print(a);
 /// }
 /// </code>
 /// </summary>
-internal sealed partial class FunctionDeclaration : Member {
+internal sealed partial class MethodDeclaration : Member {
     /// <param name="returnType"><see cref="TypeClause" /> of return type.</param>
-    /// <param name="identifier">Name of the function.</param>
-    internal FunctionDeclaration(
+    /// <param name="identifier">Name of the method.</param>
+    internal MethodDeclaration(
         SyntaxTree syntaxTree, TypeClause returnType, Token identifier, Token openParenthesis,
         SeparatedSyntaxList<Parameter> parameters, Token closeParenthesis, BlockStatement body)
         : base(syntaxTree) {
@@ -31,7 +31,7 @@ internal sealed partial class FunctionDeclaration : Member {
     internal TypeClause returnType { get; }
 
     /// <summary>
-    /// Name of the function.
+    /// Name of the method.
     /// </summary>
     internal Token identifier { get; }
 

--- a/src/Buckle/Buckle/Diagnostics/BelteException.cs
+++ b/src/Buckle/Buckle/Diagnostics/BelteException.cs
@@ -6,7 +6,7 @@ namespace Buckle.Diagnostics;
 /// Exception base class for all Belte related exceptions. Not meant to be used directly unless necessary, similar to
 /// the usage of Exception.
 /// </summary>
-internal class BelteException : Exception {
+internal abstract class BelteException : Exception {
     public BelteException() { }
 
     public BelteException(string message) : base(message) { }
@@ -17,7 +17,7 @@ internal class BelteException : Exception {
 /// <summary>
 /// Belte exception meant to be used for critical errors in the compiler when using Diagnostics is not an option.
 /// </summary>
-internal class BelteInternalException : BelteException {
+internal sealed class BelteInternalException : BelteException {
     public BelteInternalException() { }
 
     public BelteInternalException(string message) : base(message) { }
@@ -28,7 +28,7 @@ internal class BelteInternalException : BelteException {
 /// <summary>
 /// Belte exception meant to be used for exceptions in Belte source code to be shown and fixed by the user.
 /// </summary>
-internal class BelteLanguageException : BelteException {
+internal sealed class BelteLanguageException : BelteException {
     public BelteLanguageException() { }
 
     public BelteLanguageException(string message) : base(message) { }

--- a/src/Buckle/Buckle/Diagnostics/DiagnosticCodes.cs
+++ b/src/Buckle/Buckle/Diagnostics/DiagnosticCodes.cs
@@ -21,7 +21,7 @@ internal enum DiagnosticCode : int {
     ERR_RequiredMethodNotFound = 15,
     ERR_MainAndGlobals = 16,
     ERR_UndefinedName = 17,
-    ERR_FunctionAlreadyDeclared = 18,
+    ERR_MethodAlreadyDeclared = 18,
     ERR_NotAllPathsReturn = 19,
     ERR_CannotConvert = 20,
     ERR_AlreadyDeclared = 21,

--- a/src/Buckle/Buckle/Diagnostics/DiagnosticCodes.cs
+++ b/src/Buckle/Buckle/Diagnostics/DiagnosticCodes.cs
@@ -5,8 +5,7 @@ internal enum DiagnosticCode : int {
     Unknown = 0,
 
     WRN_AlwaysValue = 1,
-
-    // ? Missing 2
+    WRN_NullDeference = 2,
     ERR_InvalidReference = 3,
     ERR_InvalidType = 4,
     ERR_BadCharacter = 5,
@@ -67,6 +66,7 @@ internal enum DiagnosticCode : int {
     ERR_InvalidTernaryOperatorUse = 60,
     ERR_NoSuchMember = 61,
     ERR_CannotAssign = 62,
+    ERR_CannotOverloadNested = 63,
 
     // Carving out >=9000 for unsupported errors
     UNS_GlobalReturnValue = 9000,

--- a/src/Buckle/Buckle/Diagnostics/Errors.cs
+++ b/src/Buckle/Buckle/Diagnostics/Errors.cs
@@ -157,9 +157,9 @@ internal static class Error {
         return new BelteDiagnostic(ErrorInfo(DiagnosticCode.ERR_UndefinedName), location, message);
     }
 
-    internal static BelteDiagnostic FunctionAlreadyDeclared(TextLocation location, string name) {
-        var message = $"redefinition of function '{name}'";
-        return new BelteDiagnostic(ErrorInfo(DiagnosticCode.ERR_FunctionAlreadyDeclared), location, message);
+    internal static BelteDiagnostic MethodAlreadyDeclared(TextLocation location, string name) {
+        var message = $"redefinition of method '{name}'";
+        return new BelteDiagnostic(ErrorInfo(DiagnosticCode.ERR_MethodAlreadyDeclared), location, message);
     }
 
     internal static BelteDiagnostic NotAllPathsReturn(TextLocation location) {

--- a/src/Buckle/Buckle/Diagnostics/Errors.cs
+++ b/src/Buckle/Buckle/Diagnostics/Errors.cs
@@ -75,7 +75,7 @@ internal static class Error {
     }
 
     internal static BelteDiagnostic UnexpectedToken(
-        TextLocation location, SyntaxType unexpected, SyntaxType? expected=null) {
+        TextLocation location, SyntaxType unexpected, SyntaxType? expected = null) {
         string message;
 
         if (expected == null)
@@ -179,6 +179,10 @@ internal static class Error {
 
     internal static BelteDiagnostic ConstantAssignment(TextLocation location, string name) {
         var message = $"assignment of constant variable '{name}'";
+
+        if (name == null)
+            message = "assignment of constant";
+
         return new BelteDiagnostic(ErrorInfo(DiagnosticCode.ERR_ConstantAssignment), location, message);
     }
 
@@ -387,5 +391,10 @@ internal static class Error {
     internal static BelteDiagnostic CannotAssign(TextLocation location) {
         var message = "left side of assignment operation must be a variable or field";
         return new BelteDiagnostic(ErrorInfo(DiagnosticCode.ERR_CannotAssign), location, message);
+    }
+
+    internal static BelteDiagnostic CannotOverloadNested(TextLocation location, string name) {
+        var message = $"cannot overload nested functions; nested function '{name}' has already been declared";
+        return new BelteDiagnostic(ErrorInfo(DiagnosticCode.ERR_CannotOverloadNested), location, message);
     }
 }

--- a/src/Buckle/Buckle/Diagnostics/Warnings.cs
+++ b/src/Buckle/Buckle/Diagnostics/Warnings.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Buckle.CodeAnalysis.Text;
 using Buckle.CodeAnalysis.Syntax;
 using Diagnostics;
+using System;
 
 namespace Buckle.Diagnostics;
 
@@ -51,5 +52,10 @@ internal static class Warning {
 
         var message = $"expression will always result to '{value}'";
         return new BelteDiagnostic(WarningInfo(DiagnosticCode.WRN_AlwaysValue), location, message);
+    }
+
+    internal static BelteDiagnostic NullDeference(TextLocation location) {
+        var message = "deference of a possibly null value";
+        return new BelteDiagnostic(WarningInfo(DiagnosticCode.WRN_NullDeference), location, message);
     }
 }

--- a/src/Buckle/Buckle/IO/TextWriterExtensions.cs
+++ b/src/Buckle/Buckle/IO/TextWriterExtensions.cs
@@ -5,7 +5,6 @@ using Buckle.CodeAnalysis.Syntax;
 
 namespace Buckle.IO;
 
-// TODO Use REPL color themes instead of hard coding colors
 /// <summary>
 /// Extensions for the TextWriter object, writes text with predefined colors.
 /// </summary>

--- a/src/Buckle/Buckle/Utilities/CastUtilities.cs
+++ b/src/Buckle/Buckle/Utilities/CastUtilities.cs
@@ -1,0 +1,30 @@
+using System;
+using Buckle.CodeAnalysis.Symbols;
+
+namespace Buckle.Utilities;
+
+public static class CastUtilities {
+    /// <summary>
+    /// Casts a value to another type based on the given target type.
+    /// </summary>
+    /// <param name="value">What to cast.</param>
+    /// <param name="typeClause">The target type of the value.</param>
+    /// <returns>The casted value, does not wrap conversion exceptions.</returns>
+    internal static object Cast(object value, TypeSymbol targetType) {
+        if (targetType == TypeSymbol.Bool) {
+            return Convert.ToBoolean(value);
+        } else if (targetType == TypeSymbol.Int) {
+            // Prevents bankers rounding from Convert.ToInt32, instead always truncate (no rounding)
+            if (value.IsFloatingPoint())
+                value = Math.Truncate(Convert.ToDouble(value));
+
+            return Convert.ToInt32(value);
+        } else if (targetType == TypeSymbol.Decimal) {
+            return Convert.ToDouble(value);
+        } else if (targetType == TypeSymbol.String) {
+            return Convert.ToString(value);
+        } else {
+            return value;
+        }
+    }
+}

--- a/src/Buckle/Buckle/Utilities/FunctionUtilities.cs
+++ b/src/Buckle/Buckle/Utilities/FunctionUtilities.cs
@@ -4,7 +4,17 @@ using Buckle.Diagnostics;
 
 namespace Buckle.Utilities;
 
-static class FunctionUtilities {
+/// <summary>
+/// Utilities related to the <see cref="FunctionSymbol" /> class.
+/// </summary>
+public static class FunctionUtilities {
+    /// <summary>
+    /// Searches for a function inside a dictionary of functions.
+    /// </summary>
+    /// <param name="functions">What to search.</param>
+    /// <param name="function">What to search for.</param>
+    /// <typeparam name="T">The value type of the dictionary.</typeparam>
+    /// <returns>The value of the found pair in the dictionary, throws if the function is not found.</returns>
     internal static T LookupMethod<T>(
         IDictionary<FunctionSymbol, T> functions, FunctionSymbol function) {
         foreach (var pair in functions)


### PR DESCRIPTION
Lots of small cleanup across the repo, main changes are:
- Added -Werror, -Wall, and -Wignore command-line options
- Classifier now fully supports structs
- Unit tests can now assert exceptions
- Nested functions can no longer be overloaded
- The REPL #dump command now shows overloads
- The CreateCfg function works again
- Evaluator now has more helper functions that will make future development in the Evaluator easier
- The SyntaxTree PrettyPrint was improved
- New NullDeference warning 