### PR TITLE
Rw/const_fields

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,8 +9,6 @@
             "program": "${workspaceFolder}/src/Buckle/CommandLine/bin/Debug/net8.0/CommandLine.dll",
             "args": [
                 "-r"
-                // "./.tests/CPUEmulator",
-                // "-i",
             ],
             "cwd": "${workspaceFolder}",
             "console": "externalTerminal",

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Emitting/EmitterTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Emitting/EmitterTests.cs
@@ -474,8 +474,11 @@ namespace EmitterTests;
 public static class Program {
 
     public static void Main() {
-        Nullable<int> temp0 = ((Add(2, 3).HasValue && Add(5, 6).HasValue) ? (Nullable<int>)(Add(2, 3).Value + Add(5, 6).Value) : null);
-        Console.Write((object)((temp0.HasValue && Add(1, 5).HasValue) ? (Nullable<int>)(temp0.Value + Add(1, 5).Value) : null));
+        Nullable<int> temp0 = Add(2, 3);
+        Nullable<int> temp1 = Add(5, 6);
+        Nullable<int> temp2 = ((temp0.HasValue && temp1.HasValue) ? (Nullable<int>)(temp0.Value + temp1.Value) : null);
+        Nullable<int> temp3 = Add(1, 5);
+        Console.Write((object)((temp2.HasValue && temp3.HasValue) ? (Nullable<int>)(temp2.Value + temp3.Value) : null));
         Console.Write((object)Add(null, null));
         Console.Write((object)Add(1, null));
         Console.Write((object)Add(null, 2));

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -328,6 +328,11 @@ public sealed class EvaluatorTests {
     [InlineData("class A { int a; void SetA(int a) { this.a = 1; a = a; } int GetA() { return a; } } var myA = new A(); myA.SetA(3); return myA.GetA();", 1)]
     [InlineData("class A { int M() { return 1; } int N() { int M() { return 2; } return M(); } } var myVar = new A(); return myVar.N();", 2)]
     [InlineData("class A { int M() { return 1; } int N() { int M() { return 2; } return this.M(); } } var myVar = new A(); return myVar.N();", 1)]
+    // Static member access
+    [InlineData("class A { const int a = 3; } return A.a;", 3)]
+    [InlineData("class A { const int a; } return A.a;", null)]
+    [InlineData("class A { static int B() { return 0; } } return A.B();", 0)]
+    [InlineData("class A { static int B(int a) { return a + 3; } } return A.B(4);", 7)]
     public void Evaluator_Computes_CorrectValues(string text, object expectedValue) {
         AssertValue(text, expectedValue);
     }

--- a/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
+++ b/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
@@ -963,20 +963,21 @@ public sealed class DiagnosticTests {
         AssertDiagnostics(text, diagnostics, _writer);
     }
 
-    [Fact]
-    public void Reports_Error_BU0074_CannotUseConst() {
-        var text = @"
-            class MyClass {
-                [const] int myField;
-            }
-        ";
+    // TODO See BU0091 todo
+    // [Fact]
+    // public void Reports_Error_BU0074_CannotUseConst() {
+    //     var text = @"
+    //         class MyClass {
+    //             [const] int myField;
+    //         }
+    //     ";
 
-        var diagnostics = @"
-            cannot use a constant in this context
-        ";
+    //     var diagnostics = @"
+    //         cannot use a constant in this context
+    //     ";
 
-        AssertDiagnostics(text, diagnostics, _writer);
-    }
+    //     AssertDiagnostics(text, diagnostics, _writer);
+    // }
 
     [Fact]
     public void Reports_Error_BU0075_CannotUseRef() {
@@ -1219,18 +1220,19 @@ public sealed class DiagnosticTests {
         AssertDiagnostics(text, diagnostics, _writer);
     }
 
-    [Fact]
-    public void Reports_Error_Unsupported_BU9004_CannotInitialize() {
-        var text = @"
-            class A {
-                int num [=] 3;
-            }
-        ";
+    // TODO Add a flag to mark 'text' as low-level to allow struct syntax: the only way to produce this diagnostic
+    // [Fact]
+    // public void Reports_Error_Unsupported_BU0091_CannotInitializeInStructs() {
+    //     var text = @"
+    //         struct A {
+    //             int num [=] 3;
+    //         }
+    //     ";
 
-        var diagnostics = @"
-            cannot initialize declared symbol in this context
-        ";
+    //     var diagnostics = @"
+    //         cannot initialize fields in structure definitions
+    //     ";
 
-        AssertDiagnostics(text, diagnostics, _writer);
-    }
+    //     AssertDiagnostics(text, diagnostics, _writer);
+    // }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundMemberAccessExpression.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundMemberAccessExpression.cs
@@ -17,12 +17,16 @@ internal sealed class BoundMemberAccessExpression : BoundExpression {
         this.isNullConditional = isNullConditional;
         this.type = type;
         this.isStaticAccess = isStaticAccess;
+
+        if (member is FieldSymbol f && f.isConstant)
+            constantValue = f.constantValue;
     }
 
     internal override BoundNodeKind kind => BoundNodeKind.MemberAccessExpression;
 
-    // internal override BoundType type => BoundType.CopyWith(member.type, isConstantReference: false, isReference: true);
     internal override BoundType type { get; }
+
+    internal override BoundConstant constantValue { get; }
 
     internal BoundExpression operand { get; }
 

--- a/src/Buckle/Compiler/CodeAnalysis/Emitting/CSharpEmitter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Emitting/CSharpEmitter.cs
@@ -167,8 +167,10 @@ internal sealed class CSharpEmitter {
             foreach (var parameter in @class.members.OfType<ParameterSymbol>())
                 EmitTemplateParameter(indentedTextWriter, parameter);
 
-            foreach (var field in @class.members.OfType<FieldSymbol>())
-                EmitField(indentedTextWriter, field);
+            foreach (var field in @class.members.OfType<FieldSymbol>()) {
+                if (!field.isConstant)
+                    EmitField(indentedTextWriter, field);
+            }
 
             indentedTextWriter.WriteLine();
 
@@ -552,6 +554,9 @@ internal sealed class CSharpEmitter {
             case BoundNodeKind.MemberAccessExpression:
                 EmitMemberAccessExpression(indentedTextWriter, (BoundMemberAccessExpression)expression);
                 break;
+            case BoundNodeKind.ThisExpression:
+                EmitThisExpression(indentedTextWriter, (BoundThisExpression)expression);
+                break;
             default:
                 throw new BelteInternalException($"EmitExpression: unexpected node '{expression.kind}'");
         }
@@ -801,5 +806,9 @@ internal sealed class CSharpEmitter {
         IndentedTextWriter indentedTextWriter, BoundMemberAccessExpression expression) {
         EmitExpression(indentedTextWriter, expression.operand);
         indentedTextWriter.Write($".{GetSafeName(expression.member.name)}");
+    }
+
+    private void EmitThisExpression(IndentedTextWriter indentedTextWriter, BoundThisExpression _) {
+        indentedTextWriter.Write("this");
     }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
@@ -36,7 +36,6 @@ internal sealed class Expander : BoundTreeExpander {
         return statements;
     }
 
-
     protected override List<BoundStatement> ExpandVariableDeclarationStatement(
         BoundVariableDeclarationStatement statement) {
         _localNames.Add(statement.variable.name);
@@ -64,6 +63,23 @@ internal sealed class Expander : BoundTreeExpander {
 
         var baseStatements = base.ExpandCompoundAssignmentExpression(expression, out replacement);
         _compoundAssignmentDepth--;
+        return baseStatements;
+    }
+
+    protected override List<BoundStatement> ExpandCallExpression(
+        BoundCallExpression expression,
+        out BoundExpression replacement) {
+        if (_operatorDepth > 0) {
+            var statements = base.ExpandCallExpression(expression, out var callReplacement);
+            var tempLocal = GenerateTempLocal(expression.type);
+
+            statements.Add(new BoundVariableDeclarationStatement(tempLocal, callReplacement));
+            replacement = new BoundVariableExpression(tempLocal);
+
+            return statements;
+        }
+
+        var baseStatements = base.ExpandCallExpression(expression, out replacement);
         return baseStatements;
     }
 

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Security.Cryptography;
 using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.Symbols;
 using static Buckle.CodeAnalysis.Binding.BoundFactory;

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/Parser.ParserContext.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/Parser.ParserContext.cs
@@ -10,5 +10,6 @@ internal sealed partial class Parser {
         InTemplateArgumentList = 1 << 1,
         InClassDefinition = 1 << 2,
         InStatement = 1 << 3,
+        InStructDefinition = 1 << 4,
     }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/BuiltinFunctions.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/BuiltinFunctions.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using Buckle.CodeAnalysis.Binding;
+using static Buckle.CodeAnalysis.Binding.BoundFactory;
 
 namespace Buckle.CodeAnalysis.Symbols;
 
@@ -179,6 +180,19 @@ internal static class BuiltinMethods {
             new ParameterSymbol("value", BoundType.NullableString, 0, NoDefault)
         ),
         BoundType.Bool
+    );
+
+    /// <summary>
+    /// Converts an integer into a base 16 representation.
+    /// Optionally adds the '0x' prefix.
+    /// </summary>
+    internal static readonly MethodSymbol Hex = new MethodSymbol(
+        "Hex",
+        ImmutableArray.Create(
+            new ParameterSymbol("value", BoundType.NullableInt, 0, NoDefault),
+            new ParameterSymbol("prefix", BoundType.Bool, 0, Literal(false, BoundType.Bool))
+        ),
+        BoundType.String
     );
 
     private static ImmutableArray<ParameterSymbol> NoParameters {

--- a/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
+++ b/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
@@ -99,11 +99,11 @@ internal enum DiagnosticCode : int {
     ERR_InvalidModifier = 88,
     ERR_InvalidInstanceReference = 89,
     ERR_InvalidStaticReference = 90,
+    ERR_CannotInitializeInStructs = 91,
 
     // Carving out >=9000 for unsupported errors
     UNS_GlobalReturnValue = 9000,
     UNS_Assembling = 9001,
     UNS_Linking = 9002,
     UNS_IndependentCompilation = 9003,
-    UNS_CannotInitialize = 9004,
 }

--- a/src/Buckle/Compiler/Diagnostics/Error.cs
+++ b/src/Buckle/Compiler/Diagnostics/Error.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text;
 using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.Symbols;
@@ -26,14 +25,6 @@ internal static class Error {
         internal static BelteDiagnostic GlobalReturnValue(TextLocation location) {
             var message = "unsupported: global return cannot return a value";
             return new BelteDiagnostic(ErrorInfo(DiagnosticCode.UNS_GlobalReturnValue), location, message);
-        }
-
-        /// <summary>
-        /// BU9004. Run `buckle --explain BU9004` on the command line for more info.
-        /// </summary>
-        internal static Diagnostic CannotInitialize() {
-            var message = "cannot initialize declared symbol in this context";
-            return new Diagnostic(ErrorInfo(DiagnosticCode.UNS_CannotInitialize), message);
         }
     }
 
@@ -850,6 +841,14 @@ internal static class Error {
     internal static BelteDiagnostic InvalidStaticReference(TextLocation location, string name) {
         var message = $"an object reference is required for non-static member `{name}`";
         return new BelteDiagnostic(ErrorInfo(DiagnosticCode.ERR_InvalidStaticReference), location, message);
+    }
+
+    /// <summary>
+    /// BU0091. Run `buckle --explain BU0091` on the command line for more info.
+    /// </summary>
+    internal static Diagnostic CannotInitializeInStructs() {
+        var message = "cannot initialize fields in structure definitions";
+        return new Diagnostic(ErrorInfo(DiagnosticCode.ERR_CannotInitializeInStructs), message);
     }
 
     private static DiagnosticInfo ErrorInfo(DiagnosticCode code) {

--- a/src/Buckle/Compiler/Resources/ErrorDescriptionsBU.txt
+++ b/src/Buckle/Compiler/Resources/ErrorDescriptionsBU.txt
@@ -1443,6 +1443,18 @@ if (2 == 2)
 else
     return 3; // This is not allowed
 ```
+$BU0091
+Fields cannot be initialized when they are declared in structures. This is to
+keep structures functionally primitive, as they should only be used in low-level
+contexts when they are necessary anyways.
+
+For example:
+
+```
+struct MyStruct {
+    int myField = 3; // Not allowed
+}
+```
 $BU9001
 Assembling natively is currently unsupported. If it is requested to assemble
 natively, the compilation will not raise an error but rather ignore the request.
@@ -1461,14 +1473,3 @@ natively, this error is raised.
 
 Compiling with .NET integration is the priority, so compiling natively will
 likely be unsupported for many versions.
-$BU9004
-Fields cannot be initialized when they are declared. This will be changed in a
-future version but currently an attempt to do this will raise this error.
-
-For example:
-
-```
-class MyClass {
-    int myMember = 3; // Not allowed currently
-}
-```


### PR DESCRIPTION
# Description

Added const fields. Similar to static methods, can be accessed without a class instance. (Same as regular consts, find and replace.)

**If applicable:**

Fixed bug where an expanded *nary expression would repeat behaviour multiple times: Once when checking if the expression has a value and one when getting the value of the expression.

Old behavior (Notice how `FetchByte()` is being called a total of 4 times, when the source code only expects it to be called twice):

![image](https://github.com/ryanwilsond/belte/assets/73757164/4532ebd5-b04e-44a3-87ea-14fa9dad820b)

New (expected) behavior (`FetchByte()` called correct number of times):

![image](https://github.com/ryanwilsond/belte/assets/73757164/d048d66a-1c94-47dc-ab34-fc145008b8d3)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have added XML comments to any internal or public members and classes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I updated the error resource docs (e.g. [src/Buckle/Compiler/Resources/ErrorDescriptionsBU.txt](../src/Buckle/Compiler/Resources/ErrorDescriptionsBU.txt)) if any new errors or warnings were added
- [x] I have added a test case(s) to the diagnostics tests (e.g. [src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs](../src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs)) if any new errors or warnings were added

**If no new syntax was added delete this section:**

Make sure to update each of the following places to support your new syntax. Please delete items that are not relevant.

- [x] I added my new syntax to [Syntax.xml](../src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml) file
- [x] I updated the Parser class
- [x] I updated the Binder class
- [x] I updated the Expander class
- [x] I updated the Evaluator class
- [x] I updated the CSharpEmitter class
~~I updated the ILEmitter class~~ (Temporarily not required)
