### PR TITLE
Profiling

### DIFF
--- a/src/Tools/Profiler/Profiler.CaseResult.cs
+++ b/src/Tools/Profiler/Profiler.CaseResult.cs
@@ -1,0 +1,25 @@
+namespace Profiling;
+
+public static partial class Profiler {
+    private class CaseResult {
+        internal int eBt;
+        internal int eEMt;
+        internal int eEXt;
+        internal int iIt;
+        internal int evBt;
+        internal int evEt;
+
+        internal string eE;
+        internal string iE;
+        internal string evE;
+
+        internal void Add(CaseResult other) {
+            eBt += other.eBt;
+            eEMt += other.eEMt;
+            eEXt += other.eEXt;
+            iIt += other.iIt;
+            evBt += other.evBt;
+            evEt += other.evEt;
+        }
+    }
+}

--- a/src/Tools/Profiler/Profiler.cs
+++ b/src/Tools/Profiler/Profiler.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Buckle;
+using Buckle.CodeAnalysis;
+using Buckle.CodeAnalysis.Syntax;
+using Buckle.Diagnostics;
+using Buckle.Libraries;
+
+namespace Profiling;
+
+public static partial class Profiler {
+    private static CompilationOptions DefaultOptions
+        = new CompilationOptions(BuildMode.None, OutputKind.ConsoleApplication);
+
+    private static Compilation CorLibrary;
+
+    public static void Run(string[] args) {
+        var resultFile = File.CreateText("profiler_results.log");
+
+        // If anything unexpected happens, we don't want to waste the collected data
+        try {
+            CorLibrary = LibraryHelpers.LoadLibraries();
+            var corDiagnostics = CorLibrary.GetDiagnostics();
+            Debug.Assert(corDiagnostics.Count == 0);
+
+            for (var i = 0; i < TestCases.Length; i++) {
+                var testCase = TestCases[i];
+
+                Console.WriteLine($"Running case {i + 1}...");
+
+                resultFile.WriteLine();
+                resultFile.WriteLine();
+                resultFile.WriteLine($"Case {i + 1}:");
+                resultFile.WriteLine();
+                resultFile.WriteLine("```");
+                resultFile.WriteLine(testCase);
+                resultFile.WriteLine("```");
+                resultFile.WriteLine();
+
+                var totalCase = new CaseResult();
+                var eBts = new List<int>();
+                var eEMts = new List<int>();
+                var eEXts = new List<int>();
+                // var iIts = new List<int>();
+                var evBts = new List<int>();
+                var evEts = new List<int>();
+
+                var eFailed = false;
+                var iFailed = false;
+                var evFailed = false;
+
+                for (var j = 0; j < 20; j++) {
+                    var result = RunCase(testCase, eFailed, iFailed, evFailed);
+
+                    if (result.eE != default) {
+                        resultFile.WriteLine($"Executor failed: Case {i + 1} Run {j + 1}");
+                        resultFile.WriteLine(result.eE);
+                        eFailed = true;
+                    } else {
+                        eBts.Add(result.eBt);
+                        eEMts.Add(result.eEMt);
+                        eEXts.Add(result.eEXt);
+                    }
+
+                    // if (result.iE != default) {
+                    //     resultFile.WriteLine($"Interpreter failed: Case {i + 1} Run {j + 1}");
+                    //     resultFile.WriteLine(result.iE);
+                    //     iFailed = true;
+                    // } else {
+                    //     iIts.Add(result.iIt);
+                    // }
+
+                    if (result.evE != default) {
+                        resultFile.WriteLine($"Evaluator failed: Case {i + 1} Run {j + 1}");
+                        resultFile.WriteLine(result.evE);
+                        evFailed = true;
+                    } else {
+                        evBts.Add(result.evBt);
+                        evEts.Add(result.evEt);
+                    }
+
+                    if (j >= 3) {
+                        var mean = evEts.Average();
+                        var stddev = Math.Sqrt(evEts.Select(t => Math.Pow(t - mean, 2)).Average());
+
+                        if (stddev / mean < 0.02)
+                            break;
+                    }
+                }
+
+                var eBt = eBts.Count != 0 ? eBts.Average() : 0;
+                var eEMt = eEMts.Count != 0 ? eEMts.Average() : 0;
+                var eEXt = eEXts.Count != 0 ? eEXts.Average() : 0;
+                // var iIt = iIts.Count != 0 ? iIts.Average() : 0;
+                var evBt = evBts.Count != 0 ? evBts.Average() : 0;
+                var evEt = evEts.Count != 0 ? evEts.Average() : 0;
+
+                resultFile.WriteLine($"Executor: {eBt + eEMt + eEXt:F3} ms");
+                resultFile.WriteLine($"    Bound in ~{eBt:F3} ms");
+                resultFile.WriteLine($"    Emitted in ~{eEXt:F3} ms");
+                resultFile.WriteLine($"    Executed in ~{eEMt:F3} ms");
+                // resultFile.WriteLine($"Interpreter: {iIt:F3} ms");
+                // resultFile.WriteLine($"    Interpreted in ~{iIt:F3} ms");
+                resultFile.WriteLine($"Evaluator: {evBt + evEt:F3} ms");
+                resultFile.WriteLine($"    Bound in ~{evBt:F3} ms");
+                resultFile.WriteLine($"    Evaluated in ~{evEt:F3} ms");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Done");
+        } finally {
+            resultFile.Close();
+        }
+    }
+
+    private static void PrintDiagnostics(BelteDiagnosticQueue diagnostics) {
+        var diagnostic = diagnostics.Pop();
+
+        while (diagnostic is not null) {
+            DiagnosticFormatter.PrettyPrint(diagnostic);
+            diagnostic = diagnostics.Pop();
+        }
+    }
+
+    private static CaseResult RunCase(string testCase, bool skipE, bool skipI, bool skipEV) {
+        // Compilations and SyntaxTrees will cache results, so we have to really isolate each endpoint
+
+        var result = new CaseResult();
+
+        if (!skipE) {
+            var st1 = SyntaxTree.Parse(testCase);
+            var comp1 = Compilation.Create("Profiling", DefaultOptions, CorLibrary, st1);
+
+            try {
+                var executeDiagnostics = comp1.Execute(false, true).ToArray();
+
+                if (executeDiagnostics.Length != 3) {
+                    result.eE = $"Executor produced too many ({executeDiagnostics.Length}) diagnostics!";
+                } else {
+                    result.eBt = int.Parse(executeDiagnostics[0].message.Substring(21).Replace(" ms", ""));
+                    result.eEMt = int.Parse(executeDiagnostics[1].message.Substring(23).Replace(" ms", ""));
+                    result.eEXt = int.Parse(executeDiagnostics[2].message.Substring(24).Replace(" ms", ""));
+                }
+            } catch (Exception e) {
+                result.eE = e.Message;
+            }
+        }
+
+        // if (!skipI) {
+        //     var st2 = SyntaxTree.Parse(testCase);
+        //     var comp2 = Compilation.Create("Profiling", DefaultOptions, CorLibrary, st2);
+
+        //     try {
+        //         var interpretDiagnostics = comp2.Interpret(false, true).diagnostics.ToArray();
+
+        //         if (interpretDiagnostics.Length != 1) {
+        //             result.iE = $"Interpreter produced too many ({interpretDiagnostics.Length}) diagnostics!";
+        //         } else {
+        //             result.iIt = int.Parse(interpretDiagnostics[0].message.Substring(27).Replace(" ms", ""));
+        //         }
+        //     } catch (Exception e) {
+        //         result.iE = e.Message;
+        //     }
+        // }
+
+        if (!skipEV) {
+            var st3 = SyntaxTree.Parse(testCase);
+            var comp3 = Compilation.Create("Profiling", DefaultOptions, CorLibrary, st3);
+
+            try {
+                var evaluateDiagnostics = comp3.Evaluate(false, true).diagnostics.ToArray();
+
+
+                if (evaluateDiagnostics.Length != 2) {
+                    result.evE = $"Evaluator produced too many ({evaluateDiagnostics.Length}) diagnostics!";
+                } else {
+                    result.evBt = int.Parse(evaluateDiagnostics[0].message.Substring(21).Replace(" ms", ""));
+                    result.evEt = int.Parse(evaluateDiagnostics[1].message.Substring(25).Replace(" ms", ""));
+                }
+            } catch (Exception e) {
+                result.evE = e.Message;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Tools/Profiler/Profiler.csproj
+++ b/src/Tools/Profiler/Profiler.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Dependencies\Diagnostics\Diagnostics.csproj" />
+    <ProjectReference Include="..\..\Buckle\Compiler\Compiler.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tools/Profiler/Profiler_TestCases.cs
+++ b/src/Tools/Profiler/Profiler_TestCases.cs
@@ -1,0 +1,145 @@
+
+namespace Profiling;
+
+public static partial class Profiler {
+    private static string[] TestCases = [
+        "Console.PrintLine(\"Hello, world!\");",
+        @"
+            var sum = 0;
+            for (int! i = 0; i < 1_000_000; i++) sum += i;
+            Console.PrintLine(sum);
+        ",
+        @"
+            var p = 1;
+            for (int! i = 1; i < 20; i++) p *= i;
+            Console.PrintLine(p);
+        ",
+        @"
+            var evens = 0;
+            for (int! i = 0; i < 100000; i++) {
+                if (i % 2 == 0) evens += 1;
+            }
+            Console.PrintLine(evens);
+        ",
+        @"
+            int! a = 0;
+            for (int! i = 0; i < 10000; i++) {
+                if (i % 3 == 0) a += 1;
+                else if (i % 5 == 0) a += 2;
+                else a -= 1;
+            }
+            Console.PrintLine(a);
+        ",
+        @"
+            public static class Program {
+                static int! fib(int! n) {
+                    return n <= 1 ? n : fib(n - 1) + fib(n - 2);
+                }
+                public static void Main() {
+                    Console.PrintLine(fib(20));
+                }
+            }
+        ",
+        // TODO Broken
+        // @"
+        //     public static class Program {
+        //         static int! sum(int! acc, int! n) {
+        //             return n == 0 ? acc : sum(acc + n, n - 1);
+        //         }
+        //         public static void Main() {
+        //             Console.PrintLine(sum(0, 10000));
+        //         }
+        //     }
+        // ",
+        @"
+            class A {}
+            for (int! i = 0; i < 100000; i++) {
+                var x = new A();
+            }
+            Console.PrintLine(""done"");
+        ",
+        @"
+            class Node {
+                public Node next;
+            }
+            var head = new Node();
+            var curr = head;
+            for (int! i = 0; i < 10000; i++) {
+                curr.next = new Node();
+                curr = curr.next!;
+            }
+            Console.PrintLine(""done"");
+        ",
+        @"
+            var sum = 0;
+            for (int! i = 0; i < 100; i++) {
+                for (int! j = 0; j < 100; j++) {
+                    sum += i * j;
+                }
+            }
+            Console.PrintLine(sum);
+        ",
+        @"
+            int x = null;
+            if (x is null) {
+                x = 10;
+            }
+            Console.PrintLine(x);
+        ",
+        @"
+            int a = 5;
+            int! b = 3;
+            int result = a + b;
+            Console.PrintLine(result);
+        ",
+        @"
+            int! AddOne(int x) {
+                return x is null ? 1 : x + 1;
+            }
+            Console.PrintLine(AddOne(null));
+            Console.PrintLine(AddOne(41));
+        ",
+        @"
+            int MaybeDivide(int! x, int! y) {
+                if (y == 0) return null;
+                return x / y;
+            }
+            Console.PrintLine(MaybeDivide(10, 2));
+            Console.PrintLine(MaybeDivide(10, 0));
+        ",
+        @"
+            class A {
+                public int! value;
+            }
+
+            A a = null;
+            if (a is null) {
+                a = new A();
+                a.value = 42;
+            }
+            Console.PrintLine(a.value);
+        ",
+        @"
+            int x;
+            if (x is null) {
+                x = 7;
+            }
+            Console.PrintLine(x);
+        ",
+        @"
+            int! Square(int! x) {
+                return x * x;
+            }
+
+            int maybeX = 5;
+            if (maybeX isnt null) {
+                Console.PrintLine(Square(maybeX!));
+            }
+        ",
+        @"
+            int x = null;
+            int! y = x is null ? 123 : x!;
+            Console.PrintLine(y);
+        "
+    ];
+}

--- a/src/Tools/Profiler/Program.cs
+++ b/src/Tools/Profiler/Program.cs
@@ -1,0 +1,7 @@
+﻿using Profiling;
+
+public static class Program {
+    public static void Main(string[] args) {
+        Profiler.Run(args);
+    }
+}


### PR DESCRIPTION
# Description

Very simple profiler to compare the efficiency of the Evaluator, Interpreter, and Executor.

Findings so far:
- Interpreter is always the slowest
- Executor beats Evaluator unless the input is *very short and linear*

Next research:
- Wider variety of tests (arrays, higher heap stress, etc.)
- (Stretch) use each test and calculate node frequency scores compounded by test time to over time create a heuristic for expensive vs cheap nodes to potentially use in a deferring algorithm for using the Evaluator over Executor

The AutoRun build mode will now always default to Executor (assuming bug-free)
Can later add some logic to redirect to the Evaluator if the program is tiny and dynamic loop-free (could statically check loops and still defer to Evaluator if they are known to be small in scope)